### PR TITLE
Fixed navbar scrolling bug

### DIFF
--- a/src/renderer/components/App/App.scss
+++ b/src/renderer/components/App/App.scss
@@ -1,7 +1,7 @@
 .wrapper {
   display: grid;
   grid-template-columns: auto 1fr auto;
-  height: 100%;
+  min-height: 100vh;
   box-sizing: border-box;
 
   > * {

--- a/src/renderer/components/NavigationBar/NavigationBar.scss
+++ b/src/renderer/components/NavigationBar/NavigationBar.scss
@@ -1,11 +1,14 @@
 .navbar {
-  position: relative;
+  position: sticky;
+  top: 0;
   box-sizing: border-box;
+  max-height: 100vh;
   flex: 0 220px;
-  min-width: 68px;
-  max-width: 68px;
+  min-width: 74px;
+  max-width: 74px;
   padding: 1rem 4px;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   border-right: 1px solid #dddddd;
 
   display: flex;

--- a/src/renderer/components/NavigationBar/NavigationBar.scss
+++ b/src/renderer/components/NavigationBar/NavigationBar.scss
@@ -1,4 +1,5 @@
 .navbar {
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
   box-sizing: border-box;
@@ -27,6 +28,19 @@
     .navbar__button:hover {
       background: rgba(255, 255, 255, 0.1);
     }
+  }
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: inherit;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: #505050;
+    border-radius: 10px;
   }
 }
 


### PR DESCRIPTION
## Description
Navbar is now sticked to the top and it's height matches the viewport. If navbar items don't fit, the navbar becomes independently scrollable

## Linked issues

closes #94 

## Correct PR Checklist

- [x] I have linked an issue (use e.g. `closes #1`)
- [x] I have assigned Reviewers
- [x] I have assigned an Description label
- [ ] I have assigned a Milestone (if applicable)
