### PR TITLE
change ThemeProvide import to proper lib (MUI)

### DIFF
--- a/src/renderer/components/App/App.tsx
+++ b/src/renderer/components/App/App.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import './App.scss';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@emotion/react';
-import { CssBaseline } from '@mui/material';
+import { CssBaseline, ThemeProvider } from '@mui/material';
 import { configStore } from '../../../shared/redux/configureStore';
 import Auth from '../Auth/Auth';
 import CustomRouter from '../CustomRouter/CustomRouter';


### PR DESCRIPTION
## Description
As `ThemeProvider` was wrongly imported from `@emotion/react`, it has been change to import from `@mui/material`.

