### PR TITLE
Handle publab-settings.json not existing yet

### DIFF
--- a/src/shared/redux/slices/settingsSlice.ts
+++ b/src/shared/redux/slices/settingsSlice.ts
@@ -55,7 +55,7 @@ export const readSettingsAsync = createAsyncActionMain<void>(
   'readSettings',
   () => async (dispatch) => {
     const settings = readJSON(SETTINGS_FILE_PATH) as Settings;
-    dispatch(setSettings(settings));
+    if (settings) dispatch(setSettings(settings));
   }
 );
 


### PR DESCRIPTION
## Description

Now `setSettings` reducer will not be called if reading JSON returned `null`.

## Linked issues

Closes #142 
