### PR TITLE
Theme refactor

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,6 +4,7 @@ import { CssBaseline } from '@mui/material';
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
+  backgrounds: { disable: true },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { theme } from '../src/renderer/theme';
+import { altTheme, mainTheme } from '../src/renderer/theme';
 import { ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
 
@@ -11,10 +11,27 @@ export const parameters = {
     },
   },
 }
+export const globalTypes = {
+  theme: {
+    name: 'Theme',
+    description: 'Global theme for components',
+    defaultValue: 'main',
+    toolbar: {
+      icon: 'circlehollow',
+      items: ['main', 'alt'],
+      showName: true,
+    },
+  },
+};
+
+const themes = {
+  main: mainTheme,
+  alt: altTheme
+}
 
 export const decorators = [
-  (Story) => (
-    <ThemeProvider theme={theme}>
+  (Story, context) => (
+    <ThemeProvider theme={themes[context.globals.theme]}>
       <CssBaseline/>
       {Story()}
     </ThemeProvider>

--- a/src/renderer/components/App/App.tsx
+++ b/src/renderer/components/App/App.tsx
@@ -6,7 +6,7 @@ import { configStore } from '../../../shared/redux/configureStore';
 import Auth from '../Auth/Auth';
 import CustomRouter from '../CustomRouter/CustomRouter';
 import NavigationBar from '../NavigationBar/NavigationBar';
-import { theme } from '../../theme';
+import { mainTheme } from '../../theme';
 import observeStore from '../../../shared/redux/helpers/observeStore';
 import {
   readSettingsAsync,
@@ -29,7 +29,7 @@ const App = () => {
   );
   return (
     <Provider store={store}>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={mainTheme}>
         <CssBaseline />
         <Auth>
           <div className='wrapper'>

--- a/src/renderer/components/AuthProgress/AuthProgress.tsx
+++ b/src/renderer/components/AuthProgress/AuthProgress.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
-import { Typography } from '@mui/material';
+import { ThemeProvider, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { AUTH_STATES } from '../../../shared/redux/slices/currentUserSlice';
 import * as Styled from './style';
 import Logo from '../../assets/publab.png';
+import { altTheme } from '../../theme';
 
 const AuthProgress: React.FC<{ status: AUTH_STATES }> = ({ status }) => {
   const { t } = useTranslation();
   const key = status.toLowerCase() as Lowercase<AUTH_STATES>;
 
   return (
-    <Styled.Container>
-      <Styled.LogoImg src={Logo} alt='PubLab' />
-      <Typography variant='h5'>
-        {t('auth.in_progress')} {t(`auth.states.${key}` as const)}
-      </Typography>
-    </Styled.Container>
+    <ThemeProvider theme={altTheme}>
+      <Styled.Container>
+        <Styled.LogoImg src={Logo} alt='PubLab' />
+        <Typography variant='h5'>
+          {t('auth.in_progress')} {t(`auth.states.${key}` as const)}
+        </Typography>
+      </Styled.Container>
+    </ThemeProvider>
   );
 };
 

--- a/src/renderer/components/AuthProgress/style.ts
+++ b/src/renderer/components/AuthProgress/style.ts
@@ -11,5 +11,5 @@ export const Container = styled(Box)(({ theme }) => ({
   height: '100vh',
   width: '100vw',
   flexDirection: 'column',
-  background: theme.palette.black.main,
+  background: theme.palette.background.default,
 }));

--- a/src/renderer/components/AuthProgress/style.ts
+++ b/src/renderer/components/AuthProgress/style.ts
@@ -12,4 +12,5 @@ export const Container = styled(Box)(({ theme }) => ({
   width: '100vw',
   flexDirection: 'column',
   background: theme.palette.background.default,
+  color: theme.palette.text.primary,
 }));

--- a/src/renderer/components/Button/Button.stories.tsx
+++ b/src/renderer/components/Button/Button.stories.tsx
@@ -15,7 +15,6 @@ export const WithIcon = Template.bind({});
 WithIcon.args = {
   startIcon: <img src={GitHubIcon} alt='GitHub logo' />,
   variant: 'contained',
-  color: 'lightGray',
   children: 'Log in with GitHub',
   textCase: 'sentence-case',
   fullWidth: true,
@@ -24,24 +23,22 @@ WithIcon.args = {
 export const SentenceCase = Template.bind({});
 SentenceCase.args = {
   variant: 'contained',
-  color: 'lightGray',
   children: 'Yes, log me out.',
   textCase: 'sentence-case',
   fullWidth: true,
 };
 
-export const LightUppercase = Template.bind({});
-LightUppercase.args = {
+export const Uppercase = Template.bind({});
+Uppercase.args = {
   variant: 'contained',
-  color: 'lightGray',
   children: 'choose',
   textCase: 'uppercase',
   fontWeight: 'light',
   fullWidth: true,
 };
 
-export const BoldUppercase = Template.bind({});
-BoldUppercase.args = {
+export const BoldUppercaseGreen = Template.bind({});
+BoldUppercaseGreen.args = {
   variant: 'contained',
   color: 'green',
   children: "let's go",
@@ -50,22 +47,11 @@ BoldUppercase.args = {
   fullWidth: true,
 };
 
-export const DarkOutline = Template.bind({});
-DarkOutline.args = {
+export const Outline = Template.bind({});
+Outline.args = {
   variant: 'outlined',
   children: 'back',
   textCase: 'uppercase',
   fontWeight: 'bold',
   fullWidth: true,
-  color: 'black',
-};
-
-export const LightOutline = Template.bind({});
-LightOutline.args = {
-  variant: 'outlined',
-  children: 'back',
-  textCase: 'uppercase',
-  fontWeight: 'bold',
-  fullWidth: true,
-  color: 'lightGray',
 };

--- a/src/renderer/components/Button/Button.tsx
+++ b/src/renderer/components/Button/Button.tsx
@@ -6,26 +6,26 @@ import React, { FC } from 'react';
 import './Button.scss';
 
 interface ButtonProps extends MUIButtonProps {
-  color: keyof Palette & MUIButtonProps['color'];
   textCase?: 'lowercase' | 'uppercase' | 'sentence-case';
   fontWeight?: React.ComponentProps<typeof Typography>['fontWeight'];
+  color?: keyof Palette & MUIButtonProps['color'];
 }
 
 const Button: FC<ButtonProps> = ({
   textCase,
   fontWeight,
   children,
+  color,
   ...rest
 }) => {
-  const themeColor = useTheme().palette[rest.color];
+  const themeColor = useTheme().palette[color || 'primary'];
   return (
     <MUIButton
       className={`${textCase}`}
+      color={color}
       sx={{
         border:
-          rest.variant === 'outlined'
-            ? `1px solid ${alpha(themeColor.main, 1)}`
-            : 'none',
+          rest.variant === 'outlined' ? `1px solid ${themeColor.main}` : 'none',
         ':hover': {
           ...(rest.variant === 'contained' && {
             backgroundColor: alpha(themeColor.main, 0.8),
@@ -38,12 +38,7 @@ const Button: FC<ButtonProps> = ({
       }}
       {...rest}
     >
-      <Typography
-        fontWeight={fontWeight}
-        color={rest.color}
-        margin='1em'
-        lineHeight='1.4em'
-      >
+      <Typography fontWeight={fontWeight} margin='1em' lineHeight='1.4em'>
         {children}
       </Typography>
     </MUIButton>
@@ -53,6 +48,7 @@ const Button: FC<ButtonProps> = ({
 Button.defaultProps = {
   textCase: 'uppercase',
   fontWeight: 'normal',
+  color: 'primary',
 };
 
 export default Button;

--- a/src/renderer/components/CustomRouter/CustomRouter.scss
+++ b/src/renderer/components/CustomRouter/CustomRouter.scss
@@ -1,8 +1,6 @@
-.view {
-  background-color: #dddddd;
-  padding: 1.5rem;
+.view > * {
+  height: 100%;
 }
 
 .subview {
-  background-color: #111111;
 }

--- a/src/renderer/components/DirectoryPicker/DirectoryPicker.tsx
+++ b/src/renderer/components/DirectoryPicker/DirectoryPicker.tsx
@@ -27,7 +27,6 @@ const DirectoryPicker: React.FC<Props> = ({
     />
     <Button
       variant='contained'
-      color='lightGray'
       textCase='uppercase'
       fontWeight='regular'
       onClick={onClick}

--- a/src/renderer/components/RadioButton/RadioBtn.tsx
+++ b/src/renderer/components/RadioButton/RadioBtn.tsx
@@ -7,7 +7,7 @@ const RadioBtn = styled(Radio)(({ theme }) => ({
     color: theme.palette.primary.main,
   },
   '&.Mui-disabled': {
-    color: theme.palette.darkGray.main,
+    color: theme.palette.text.disabled,
   },
 }));
 

--- a/src/renderer/components/RadioButton/RadioBtn.tsx
+++ b/src/renderer/components/RadioButton/RadioBtn.tsx
@@ -2,9 +2,9 @@ import { styled } from '@mui/material/styles';
 import Radio from '@mui/material/Radio';
 
 const RadioBtn = styled(Radio)(({ theme }) => ({
-  color: theme.palette.lightGray.main,
+  color: theme.palette.primary.main,
   '&.Mui-checked': {
-    color: theme.palette.lightGray.main,
+    color: theme.palette.primary.main,
   },
   '&.Mui-disabled': {
     color: theme.palette.darkGray.main,

--- a/src/renderer/components/RadioButton/RadioGroup.stories.tsx
+++ b/src/renderer/components/RadioButton/RadioGroup.stories.tsx
@@ -14,10 +14,7 @@ interface Props {
 }
 
 const RadioForm: React.FC<Props> = ({ disabled1, disabled2, defaults }) => (
-  <FormControl
-    component='fieldset'
-    style={{ background: 'black', padding: '2rem' }}
-  >
+  <FormControl component='fieldset' style={{ padding: '2rem' }}>
     <Box pb={4} pt={2}>
       <FormLabel component='legend'>
         <Typography variant='h4' color='text.primary'>

--- a/src/renderer/components/Select/Select.tsx
+++ b/src/renderer/components/Select/Select.tsx
@@ -21,18 +21,18 @@ const StyledSelect = styled(MuiSelect)(({ theme }) => ({
 
   '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
     borderWidth: '1px',
-    borderColor: theme.palette.lightGray.main,
+    borderColor: theme.palette.primary.main,
   },
 
   '& .MuiOutlinedInput-notchedOutline': {
-    borderColor: theme.palette.lightGray.main,
+    borderColor: theme.palette.primary.main,
   },
   '&.Mui-disabled .MuiOutlinedInput-notchedOutline': {
     borderColor: theme.palette.darkGray.main,
   },
 
   '& .MuiSelect-icon': {
-    fill: theme.palette.lightGray.main,
+    fill: theme.palette.primary.main,
   },
   '&.Mui-disabled .MuiSelect-icon': {
     fill: theme.palette.darkGray.main,
@@ -42,9 +42,9 @@ const StyledSelect = styled(MuiSelect)(({ theme }) => ({
 const menuListProps: Partial<MenuProps> = {
   MenuListProps: {
     sx: {
-      bgcolor: (theme) => theme.palette.lightGray.main,
+      bgcolor: (theme) => theme.palette.primary.main,
       '& .MuiMenuItem-root': {
-        color: (theme) => theme.palette.black.main,
+        color: (theme) => theme.palette.secondary.main,
         '&.Mui-selected, &.Mui-selected:hover': {
           bgcolor: (theme) => theme.palette.gray.main,
         },

--- a/src/renderer/components/Switch/Switch.tsx
+++ b/src/renderer/components/Switch/Switch.tsx
@@ -10,7 +10,7 @@ const StyledSwitch = styled(Switch)(({ theme }) => ({
     height: '100%',
     marginLeft: '10%',
     transitionDuration: '300ms',
-    borderColor: theme.palette.lightGray.main,
+    borderColor: theme.palette.primary.main,
     '&.Mui-checked': {
       transform: 'translateX(160%)',
       '& + .MuiSwitch-track': {
@@ -23,14 +23,14 @@ const StyledSwitch = styled(Switch)(({ theme }) => ({
   '& .MuiSwitch-thumb': {
     width: 25,
     height: 25,
-    color: theme.palette.lightGray.main,
+    color: theme.palette.primary.main,
   },
 
   '& .MuiSwitch-track': {
     borderRadius: 20,
     backgroundColor: 'transparent',
     opacity: 1,
-    border: `1px solid ${theme.palette.lightGray.main}`,
+    border: `1px solid ${theme.palette.primary.main}`,
   },
 }));
 

--- a/src/renderer/components/TextArea/TextArea.stories.tsx
+++ b/src/renderer/components/TextArea/TextArea.stories.tsx
@@ -12,20 +12,13 @@ const Template: ComponentStory<typeof TextArea> = (args) => (
   <TextArea {...args} />
 );
 
-export const Light = Template.bind({});
-Light.args = {
-  type: 'light',
-  placeholder: 'Project name ...',
-};
-
-export const Dark = Template.bind({});
-Dark.args = {
-  type: 'dark',
+export const Base = Template.bind({});
+Base.args = {
   placeholder: 'Project name ...',
 };
 
 export const Error = Template.bind({});
 Error.args = {
-  type: 'error',
+  error: true,
   placeholder: 'Project name ...',
 };

--- a/src/renderer/components/TextArea/TextArea.tsx
+++ b/src/renderer/components/TextArea/TextArea.tsx
@@ -3,7 +3,7 @@ import { InputBaseProps } from '@mui/material';
 import TextField from '../TextField/TextField';
 
 const TextArea: React.FC<InputBaseProps> = (props) => (
-  <TextField rows={6} maxRows={10} {...props} multiline />
+  <TextField rows={6} {...props} multiline />
 );
 
 export default TextArea;

--- a/src/renderer/components/TextField/TextField.stories.tsx
+++ b/src/renderer/components/TextField/TextField.stories.tsx
@@ -13,23 +13,14 @@ const Template: ComponentStory<typeof TextField> = (args) => (
   <TextField {...args} />
 );
 
-export const Light = Template.bind({});
-Light.args = {
-  type: 'light',
-  error: false,
-  placeholder: 'Project name...',
-};
-
-export const Dark = Template.bind({});
-Dark.args = {
-  type: 'dark',
+export const Base = Template.bind({});
+Base.args = {
   error: false,
   placeholder: 'Project name...',
 };
 
 export const Error = Template.bind({});
 Error.args = {
-  type: 'dark',
   error: true,
   placeholder: 'Project name...',
 };

--- a/src/renderer/components/TextField/TextField.tsx
+++ b/src/renderer/components/TextField/TextField.tsx
@@ -2,10 +2,10 @@ import { InputBase } from '@mui/material';
 import './TextField.scss';
 import { styled } from '@mui/material/styles';
 
-export default styled(InputBase)(({ type, error, theme: { palette } }) => {
-  const { lightGray, black, lightRed } = palette;
+export default styled(InputBase)(({ error, theme: { palette } }) => {
+  const { primary, lightRed } = palette;
 
-  let color = type === 'light' ? black.main : lightGray.main;
+  let color = primary.main;
   if (error) color = lightRed.main;
 
   const border = `1px solid ${color}`;

--- a/src/renderer/components/ViewContent/ViewContent.tsx
+++ b/src/renderer/components/ViewContent/ViewContent.tsx
@@ -2,9 +2,9 @@ import { BoxProps } from '@mui/material';
 import React from 'react';
 import { BackgroundWrapper, ContentBox } from './style';
 
-const ViewContent: React.FC<BoxProps> = (props) => (
-  <BackgroundWrapper {...props}>
-    <ContentBox>{props.children}</ContentBox>
+const ViewContent: React.FC<BoxProps> = ({ children, ...rest }) => (
+  <BackgroundWrapper {...rest}>
+    <ContentBox>{children}</ContentBox>
   </BackgroundWrapper>
 );
 

--- a/src/renderer/components/ViewContent/ViewContent.tsx
+++ b/src/renderer/components/ViewContent/ViewContent.tsx
@@ -1,0 +1,11 @@
+import { BoxProps } from '@mui/material';
+import React from 'react';
+import { BackgroundWrapper, ContentBox } from './style';
+
+const ViewContent: React.FC<BoxProps> = (props) => (
+  <BackgroundWrapper {...props}>
+    <ContentBox>{props.children}</ContentBox>
+  </BackgroundWrapper>
+);
+
+export default ViewContent;

--- a/src/renderer/components/ViewContent/style.ts
+++ b/src/renderer/components/ViewContent/style.ts
@@ -1,8 +1,9 @@
 import { Box, styled } from '@mui/material';
 
-export const BackgroundWrapper = styled(Box)(() => ({
+export const BackgroundWrapper = styled(Box)(({ theme }) => ({
   display: 'flex',
   justifyContent: 'center',
+  backgroundColor: theme.palette.background.default,
 }));
 
 export const ContentBox = styled(Box)(() => ({

--- a/src/renderer/components/ViewContent/style.ts
+++ b/src/renderer/components/ViewContent/style.ts
@@ -1,0 +1,11 @@
+import { Box, styled } from '@mui/material';
+
+export const BackgroundWrapper = styled(Box)(() => ({
+  display: 'flex',
+  justifyContent: 'center',
+}));
+
+export const ContentBox = styled(Box)(() => ({
+  minWidth: '400px',
+  width: '50vw',
+}));

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -65,52 +65,61 @@ const hkgroteskExtraBold = {
   `,
 };
 
-export const theme = responsiveFontSizes(
+const commonColors = {
+  black: '#111111',
+  lightGrey: '#DDDDDD',
+};
+
+export const mainTheme = responsiveFontSizes(
   createTheme({
     palette: {
+      mode: 'light',
       text: {
-        primary: '#DDDDDD',
-        secondary: '#111111',
+        primary: commonColors.black,
+        secondary: commonColors.lightGrey,
       },
-      black: {
-        main: '#111111', // black backgrounds
-        contrastText: '#DDDDDD',
+      background: {
+        default: commonColors.lightGrey,
       },
-      lightGray: {
-        main: '#DDDDDD', // light backgrounds
-        contrastText: '#111111',
+      primary: {
+        main: commonColors.black,
+        contrastText: commonColors.lightGrey,
+      },
+      secondary: {
+        main: commonColors.lightGrey,
+        contrastText: commonColors.black,
       },
       gray: {
         main: '#d1d1d1',
-        contrastText: '#111111',
+        contrastText: commonColors.black,
       },
       darkGray: {
         main: '#505050',
-        contrastText: '#DDDDDD',
+        contrastText: commonColors.lightGrey,
       },
       lightPink: {
         main: '#FFD6EA', // light pink, eg. notifications background
-        contrastText: '#111111',
+        contrastText: commonColors.black,
       },
       lightRed: {
         main: '#ff8383',
-        contrastText: '#DDDDDD',
+        contrastText: commonColors.lightGrey,
       },
       green: {
         main: '#01D39F', // green, eg. button, switches when
-        contrastText: '#111111',
+        contrastText: commonColors.black,
       },
       lightGreen: {
         main: '#EBF8EA',
-        contrastText: '#111111',
+        contrastText: commonColors.black,
       },
       orange: {
         main: '#d89e01',
-        contrastText: '#111111',
+        contrastText: commonColors.black,
       },
       blue: {
         main: '#83aeff',
-        contrastText: '#111111',
+        contrastText: commonColors.black,
       },
     },
     typography: {
@@ -153,3 +162,18 @@ export const theme = responsiveFontSizes(
     },
   })
 );
+
+export const altTheme = createTheme({
+  ...mainTheme,
+  palette: {
+    ...mainTheme.palette,
+    mode: 'dark',
+    text: {
+      primary: mainTheme.palette.text.secondary,
+      secondary: mainTheme.palette.text.primary,
+    },
+    background: { default: commonColors.black },
+    primary: mainTheme.palette.secondary,
+    secondary: mainTheme.palette.primary,
+  },
+});

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -77,6 +77,7 @@ export const mainTheme = responsiveFontSizes(
       text: {
         primary: commonColors.black,
         secondary: commonColors.lightGray,
+        disabled: '#d1d1d1',
       },
       background: {
         default: commonColors.lightGray,
@@ -179,6 +180,7 @@ export const altTheme = createTheme({
     text: {
       primary: mainTheme.palette.text.secondary,
       secondary: mainTheme.palette.text.primary,
+      disabled: mainTheme.palette.darkGray.main,
     },
     background: { default: commonColors.black },
     primary: mainTheme.palette.secondary,

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -67,7 +67,7 @@ const hkgroteskExtraBold = {
 
 const commonColors = {
   black: '#111111',
-  lightGrey: '#DDDDDD',
+  lightGray: '#DDDDDD',
 };
 
 export const mainTheme = responsiveFontSizes(
@@ -76,17 +76,25 @@ export const mainTheme = responsiveFontSizes(
       mode: 'light',
       text: {
         primary: commonColors.black,
-        secondary: commonColors.lightGrey,
+        secondary: commonColors.lightGray,
       },
       background: {
-        default: commonColors.lightGrey,
+        default: commonColors.lightGray,
       },
       primary: {
         main: commonColors.black,
-        contrastText: commonColors.lightGrey,
+        contrastText: commonColors.lightGray,
       },
       secondary: {
-        main: commonColors.lightGrey,
+        main: commonColors.lightGray,
+        contrastText: commonColors.black,
+      },
+      black: {
+        main: commonColors.black,
+        contrastText: commonColors.lightGray,
+      },
+      lightGray: {
+        main: commonColors.lightGray,
         contrastText: commonColors.black,
       },
       gray: {
@@ -95,7 +103,7 @@ export const mainTheme = responsiveFontSizes(
       },
       darkGray: {
         main: '#505050',
-        contrastText: commonColors.lightGrey,
+        contrastText: commonColors.lightGray,
       },
       lightPink: {
         main: '#FFD6EA', // light pink, eg. notifications background
@@ -103,7 +111,7 @@ export const mainTheme = responsiveFontSizes(
       },
       lightRed: {
         main: '#ff8383',
-        contrastText: commonColors.lightGrey,
+        contrastText: commonColors.lightGray,
       },
       green: {
         main: '#01D39F', // green, eg. button, switches when

--- a/src/renderer/views/AppSettings/AppSettings.tsx
+++ b/src/renderer/views/AppSettings/AppSettings.tsx
@@ -12,8 +12,11 @@ import AppUpdate from './subcomponents/AppUpdate';
 import LangSelect from './subcomponents/LangSelect';
 import DefaultDirSelect from './subcomponents/DefaultDirSelect';
 import NotificationIntervalSelect from './subcomponents/NotifIntervalSelect';
+import ViewContent from '../../components/ViewContent/ViewContent';
 
 const AppSettings = () => {
+  const color = useTheme().palette.black;
+
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [settings, changeSetting] = useReducer(
@@ -26,7 +29,7 @@ const AppSettings = () => {
   }
 
   return (
-    <div>
+    <ViewContent sx={{ backgroundColor: color.main }}>
       {t('AppSettings.title')}
       <AppUpdate />
       <LangSelect
@@ -47,7 +50,7 @@ const AppSettings = () => {
         }
       />
       <Button onClick={() => submitChanges()}>{t('common.save')}</Button>
-    </div>
+    </ViewContent>
   );
 };
 

--- a/src/renderer/views/AppSettings/AppSettings.tsx
+++ b/src/renderer/views/AppSettings/AppSettings.tsx
@@ -2,7 +2,7 @@ import React, { useReducer } from 'react';
 import './AppSettings.scss';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@mui/material';
+import { Button, ThemeProvider } from '@mui/material';
 import {
   saveSettingsAsync,
   selectAllSettings,
@@ -13,10 +13,9 @@ import LangSelect from './subcomponents/LangSelect';
 import DefaultDirSelect from './subcomponents/DefaultDirSelect';
 import NotificationIntervalSelect from './subcomponents/NotifIntervalSelect';
 import ViewContent from '../../components/ViewContent/ViewContent';
+import { altTheme } from '../../theme';
 
 const AppSettings = () => {
-  const color = useTheme().palette.black;
-
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [settings, changeSetting] = useReducer(
@@ -29,28 +28,30 @@ const AppSettings = () => {
   }
 
   return (
-    <ViewContent sx={{ backgroundColor: color.main }}>
-      {t('AppSettings.title')}
-      <AppUpdate />
-      <LangSelect
-        currentLocale={settings.currentLocale}
-        onChange={(locale) => changeSetting({ currentLocale: locale })}
-      />
-      <DefaultDirSelect
-        defaultDirPath={settings.defaultDirPath}
-        onChange={(path) => changeSetting({ defaultDirPath: path })}
-      />
-      <Button style={{ display: 'block' }} onClick={() => submitChanges()}>
-        {t('common.save')}
-      </Button>
-      <NotificationIntervalSelect
-        currentInterval={settings.notificationInterval}
-        onChange={(interval) =>
-          changeSetting({ notificationInterval: interval })
-        }
-      />
-      <Button onClick={() => submitChanges()}>{t('common.save')}</Button>
-    </ViewContent>
+    <ThemeProvider theme={altTheme}>
+      <ViewContent>
+        {t('AppSettings.title')}
+        <AppUpdate />
+        <LangSelect
+          currentLocale={settings.currentLocale}
+          onChange={(locale) => changeSetting({ currentLocale: locale })}
+        />
+        <DefaultDirSelect
+          defaultDirPath={settings.defaultDirPath}
+          onChange={(path) => changeSetting({ defaultDirPath: path })}
+        />
+        <Button style={{ display: 'block' }} onClick={() => submitChanges()}>
+          {t('common.save')}
+        </Button>
+        <NotificationIntervalSelect
+          currentInterval={settings.notificationInterval}
+          onChange={(interval) =>
+            changeSetting({ notificationInterval: interval })
+          }
+        />
+        <Button onClick={() => submitChanges()}>{t('common.save')}</Button>
+      </ViewContent>
+    </ThemeProvider>
   );
 };
 


### PR DESCRIPTION
## Description

A better implementation of themes. Most MUI components should have colors close to intended by default. Additionally, it is no longer necessary to specify whether a component is 'light' or 'dark' - it is controlled by `ThemeProvider` instead, so the component will match it's surroundings unless the color is overridden.

Main theme is 'light', as more components use it according to the design. By wrapping components in another `ThemeProvider` with `altTheme` passed to it you can change their color scheme. 

Storybook config was also updated to allow changing themes while previewing components.
