### PR TITLE
fix: :bug: make fonts load correctly

### DIFF
--- a/config/webpack.rules.js
+++ b/config/webpack.rules.js
@@ -55,8 +55,8 @@ module.exports = [
       {
         loader: 'file-loader',
         options: {
-          name: '[name].[ext]',
-          outputPath: 'fonts/',
+          name: 'fonts/[name].[ext]',
+          publicPath: isDevelopment ? './' : '../', // root url differs slightly because of the way webpack handles dev server and packaging
         },
       },
     ],

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -159,15 +159,16 @@ export const mainTheme = createTheme({
           body: {
             boxSizing: 'border-box',
           },
-
-          '@font-face': [
-            hkgrotesk,
-            hkgroteskItalic,
-            hkgroteskBold,
-            hkgroteskSemiBold,
-            hkgroteskExtraBold,
-          ],
         },
+
+        '@font-face': hkgrotesk,
+        // weird fallbacks usage due to the bug described here: https://github.com/mui-org/material-ui/issues/24966
+        fallbacks: [
+          { '@font-face': hkgroteskItalic },
+          { '@font-face': hkgroteskBold },
+          { '@font-face': hkgroteskSemiBold },
+          { '@font-face': hkgroteskExtraBold },
+        ],
       },
     },
   },


### PR DESCRIPTION
## Description
Turned out to be a bit compounded. 
- The main cause was probably nesting the `@font-face` inside the `@global` (not sure why)
- Due to a [MUI bug](https://github.com/mui-org/material-ui/issues/24966), generating multiple `@font-face` rules required a workaround - otherwise they were just overriding each other.
- Path to the assets in the packaged app has to be slightly different. The main window's root url is one step shallower on the dev server.

## Linked issues

closes #160 

