### PR TITLE
Fix a bug with devtolls extension installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^4.2.1",
     "electron": "10.4.7",
-    "electron-devtools-installer": "^3.2.0",
+    "electron-devtools-installer": "git+https://github.com/mduclehcm/electron-devtools-installer#mduclehcm-patch-1",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^14.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6108,10 +6108,9 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-devtools-installer@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.2.0.tgz#acc48d24eb7033fe5af284a19667e73b78d406d0"
-  integrity sha512-t3UczsYugm4OAbqvdImMCImIMVdFzJAHgbwHpkl5jmfu1izVgUcP/mnrPqJIpEeCK1uZGpt+yHgWEN+9EwoYhQ==
+"electron-devtools-installer@git+https://github.com/mduclehcm/electron-devtools-installer#mduclehcm-patch-1":
+  version "0.0.0-development"
+  resolved "git+https://github.com/mduclehcm/electron-devtools-installer#90bba265c31681d5449ebe10d8637f2c0aef30d6"
   dependencies:
     rimraf "^3.0.2"
     semver "^7.2.1"


### PR DESCRIPTION
The extensions are not being downloaded correctly due to an issue with the `electron-devtools-installer`. This PR changes the dependency to a version with a hotfix applied. (more [here](https://github.com/MarshallOfSound/electron-devtools-installer/issues/215))