### PR TITLE
Implement project list search

### DIFF
--- a/mui.d.ts
+++ b/mui.d.ts
@@ -28,6 +28,7 @@ declare module '@mui/material/styles' {
     pink: PaletteColor;
     red: PaletteColor;
     green: PaletteColor;
+    paleGreen: PaletteColor;
     orange: PaletteColor;
     blue: PaletteColor;
     salmon: PaletteColor;
@@ -38,6 +39,7 @@ declare module '@mui/material/styles' {
     pink?: PaletteColorOptions;
     red?: PaletteColorOptions;
     green?: PaletteColorOptions;
+    paleGreen: PaletteColorOptions;
     orange?: PaletteColorOptions;
     blue?: PaletteColorOptions;
     salmon?: PaletteColorOptions;

--- a/src/renderer/components/SearchField/SearchField.tsx
+++ b/src/renderer/components/SearchField/SearchField.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable react/prop-types */
+import { InputAdornment } from '@mui/material';
+import React from 'react';
+import SearchIcon from '@mui/icons-material/Search';
+import * as Styled from './style';
+
+type Props = React.ComponentProps<typeof Styled.SearchField>;
+
+const SearchField: React.FC<Props> = (props: Props) => (
+  <Styled.SearchField
+    {...props}
+    size='small'
+    InputProps={{
+      ...props.InputProps,
+      endAdornment: (
+        <>
+          {props.InputProps?.endAdornment}
+          <InputAdornment position='end' className='search-icon'>
+            <SearchIcon fontSize='small' />
+          </InputAdornment>
+        </>
+      ),
+    }}
+  />
+);
+
+export default SearchField;

--- a/src/renderer/components/SearchField/style.ts
+++ b/src/renderer/components/SearchField/style.ts
@@ -1,0 +1,43 @@
+import { styled, TextField } from '@mui/material';
+
+export const SearchField = styled(TextField)(({ theme }) => ({
+  '& .MuiInputBase-root.MuiInputBase-root': {
+    position: 'relative',
+    borderRadius: '1.5rem 1.5rem',
+    minHeight: '3rem',
+    minWidth: '12rem',
+    padding: `0 ${theme.spacing(1)}`,
+    border: '1px solid transparent',
+    '& *': {
+      color: theme.palette.text.primary,
+    },
+    '& .search-icon': {
+      position: 'absolute',
+      right: '0.5rem',
+      padding: '10rem 0 10rem 0.5rem',
+    },
+    '& .MuiInputBase-input': {
+      marginRight: '2rem',
+      padding: 0,
+      height: '3rem',
+    },
+    '& .MuiOutlinedInput-notchedOutline ': {
+      border: 'none',
+      padding: 0,
+    },
+    '& .MuiAutocomplete-endAdornment': {
+      display: 'none',
+    },
+    '&.Mui-focused': {
+      backgroundColor: theme.palette.paleGreen.main,
+      border: '1px solid',
+      '& *': {
+        color: theme.palette.paleGreen.contrastText,
+      },
+      '& .search-icon': {
+        borderLeft: '1px solid',
+      },
+    },
+  },
+  fontSize: '1.2rem',
+}));

--- a/src/renderer/internationalisation/locales/en/translation.json
+++ b/src/renderer/internationalisation/locales/en/translation.json
@@ -18,7 +18,8 @@
     "notification": "Notification",
     "change_date": "change date",
     "all": "all",
-    "go_back": "go back"
+    "go_back": "go back",
+    "search": "search"
   },
   "notifications": {
     "directory_not_existing": "{{dir}} directory does not exist or the path is invalid. Check the path and try again.",

--- a/src/renderer/internationalisation/locales/pl/translation.json
+++ b/src/renderer/internationalisation/locales/pl/translation.json
@@ -18,7 +18,8 @@
     "notification": "Powiadomienie",
     "change_date": "data modyfikacji",
     "all": "wszystko",
-    "go_back": "powrót"
+    "go_back": "powrót",
+    "search": "wyszukiwanie"
   },
   "notifications": {
     "directory_not_existing": "Folder {{dir}} nie istnieje lub ścieżka jest błędna. Sprawdź ścieżkę i spróbuj ponownie.",

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -127,6 +127,10 @@ export const mainTheme = createTheme({
       dark: '#33B150',
       contrastText: commonColors.black,
     },
+    paleGreen: {
+      main: '#EBF8EA',
+      contrastText: commonColors.black,
+    },
     orange: {
       main: '#d89e01',
       contrastText: commonColors.black,

--- a/src/renderer/views/ProjectsList/ProjectsList.tsx
+++ b/src/renderer/views/ProjectsList/ProjectsList.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ThemeProvider, Typography } from '@mui/material';
+import { Box, ThemeProvider, Typography } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import ViewContent from '../../components/ViewContent/ViewContent';
 import { altTheme } from '../../theme';
@@ -9,20 +9,33 @@ import Button from '../../components/Button/Button';
 import { updateCurrentView } from '../../../shared/redux/slices/currentViewSlice';
 import { VIEWS } from '../../constants/Views';
 import { loadedPublicationsList } from '../../../shared/redux/slices/loadPublicationsSlice';
+import ProjectSearch from './subcomponents/ProjectSearch/ProjectSearch';
+import { Publication } from '../../../shared/types';
 
 const ProjectsList = () => {
   const { t } = useTranslation();
 
   const dispatch = useDispatch();
   const publications = useSelector(loadedPublicationsList);
+  const [searchTerms, setSearchTerms] = useState([] as string[]);
+  const filteredPublications = useMemo(
+    () => searchFilter(publications, searchTerms),
+    [publications, searchTerms]
+  );
 
   return (
     <ThemeProvider theme={altTheme}>
       <ViewContent>
-        <Typography variant='h1' mb={4}>
-          {t('views.projects_list')}
-        </Typography>
-        <ProjectTable publications={publications} />
+        <Box mb={4} sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Typography variant='h1'>{t('views.projects_list')}</Typography>
+          <Box>
+            <ProjectSearch
+              publications={filteredPublications}
+              onChange={(terms) => setSearchTerms(terms)}
+            />
+          </Box>
+        </Box>
+        <ProjectTable publications={filteredPublications} />
         <Button
           variant='contained'
           fullWidth
@@ -38,3 +51,16 @@ const ProjectsList = () => {
 };
 
 export default ProjectsList;
+
+function searchFilter(publications: Publication[], terms: string[]) {
+  if (terms.length === 0) return publications;
+  return publications.filter((publication) =>
+    terms.every((term) =>
+      term.startsWith('#')
+        ? publication.tags.includes(term.replace('#', ''))
+        : publication.name
+            .toLocaleLowerCase()
+            .includes(term.toLocaleLowerCase())
+    )
+  );
+}

--- a/src/renderer/views/ProjectsList/ProjectsList.tsx
+++ b/src/renderer/views/ProjectsList/ProjectsList.tsx
@@ -11,6 +11,7 @@ import { VIEWS } from '../../constants/Views';
 import { loadedPublicationsList } from '../../../shared/redux/slices/loadPublicationsSlice';
 import ProjectSearch from './subcomponents/ProjectSearch/ProjectSearch';
 import { Publication } from '../../../shared/types';
+import { hasTagPrefix, removePrefix } from './formatTags';
 
 const ProjectsList = () => {
   const { t } = useTranslation();
@@ -56,8 +57,8 @@ function searchFilter(publications: Publication[], terms: string[]) {
   if (terms.length === 0) return publications;
   return publications.filter((publication) =>
     terms.every((term) =>
-      term.startsWith('#')
-        ? publication.tags.includes(term.replace('#', ''))
+      hasTagPrefix(term)
+        ? publication.tags.includes(removePrefix(term))
         : publication.name
             .toLocaleLowerCase()
             .includes(term.toLocaleLowerCase())

--- a/src/renderer/views/ProjectsList/formatTags.ts
+++ b/src/renderer/views/ProjectsList/formatTags.ts
@@ -1,0 +1,13 @@
+const TAG_PREFIX = '#';
+
+export function hasTagPrefix(string: string) {
+  return string.startsWith(TAG_PREFIX);
+}
+
+export function addPrefix(tagName: string) {
+  return TAG_PREFIX.concat(tagName);
+}
+
+export function removePrefix(tagWithPrefix: string) {
+  return tagWithPrefix.slice(TAG_PREFIX.length);
+}

--- a/src/renderer/views/ProjectsList/subcomponents/ProjectSearch/ProjectSearch.tsx
+++ b/src/renderer/views/ProjectsList/subcomponents/ProjectSearch/ProjectSearch.tsx
@@ -1,0 +1,30 @@
+import { Autocomplete } from '@mui/material';
+import React from 'react';
+import { Publication } from '../../../../../shared/types';
+import SearchField from '../../../../components/SearchField/SearchField';
+
+interface Props {
+  publications: Publication[];
+  onChange: (terms: string[]) => void;
+}
+
+const ProjectSearch: React.FC<Props> = ({ publications, onChange }) => (
+  <Autocomplete
+    options={getAutocompleteOptions(publications)}
+    onChange={(_, value) => onChange(value)}
+    renderInput={(params) => <SearchField {...params} />}
+    size='small'
+    freeSolo
+    multiple
+  />
+);
+
+export default ProjectSearch;
+
+function getAutocompleteOptions(publications: Publication[]) {
+  const options = [] as string[];
+  publications.forEach(({ tags }) => {
+    tags.forEach((tag) => !options.includes(tag) && options.push(`#${tag}`));
+  });
+  return options;
+}

--- a/src/renderer/views/ProjectsList/subcomponents/ProjectSearch/ProjectSearch.tsx
+++ b/src/renderer/views/ProjectsList/subcomponents/ProjectSearch/ProjectSearch.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Publication } from '../../../../../shared/types';
 import SearchField from '../../../../components/SearchField/SearchField';
+import { addPrefix } from '../../formatTags';
 
 interface Props {
   publications: Publication[];
@@ -36,7 +37,10 @@ export default ProjectSearch;
 function getAutocompleteOptions(publications: Publication[]) {
   const options = [] as string[];
   publications.forEach(({ tags }) => {
-    tags.forEach((tag) => !options.includes(tag) && options.push(`#${tag}`));
+    tags.forEach((tag) => {
+      const tagWithPrefix = addPrefix(tag);
+      if (!options.includes(tagWithPrefix)) options.push(tagWithPrefix);
+    });
   });
   return options;
 }

--- a/src/renderer/views/ProjectsList/subcomponents/ProjectSearch/ProjectSearch.tsx
+++ b/src/renderer/views/ProjectsList/subcomponents/ProjectSearch/ProjectSearch.tsx
@@ -1,5 +1,6 @@
 import { Autocomplete } from '@mui/material';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Publication } from '../../../../../shared/types';
 import SearchField from '../../../../components/SearchField/SearchField';
 
@@ -8,16 +9,27 @@ interface Props {
   onChange: (terms: string[]) => void;
 }
 
-const ProjectSearch: React.FC<Props> = ({ publications, onChange }) => (
-  <Autocomplete
-    options={getAutocompleteOptions(publications)}
-    onChange={(_, value) => onChange(value)}
-    renderInput={(params) => <SearchField {...params} />}
-    size='small'
-    freeSolo
-    multiple
-  />
-);
+const ProjectSearch: React.FC<Props> = ({ publications, onChange }) => {
+  const { t } = useTranslation();
+  return (
+    <Autocomplete
+      options={getAutocompleteOptions(publications)}
+      onChange={(_, value) => onChange(value)}
+      renderInput={(params) => (
+        <SearchField
+          {...params}
+          InputProps={{
+            'aria-label': t('common.search'),
+            ...params.InputProps,
+          }}
+        />
+      )}
+      size='small'
+      freeSolo
+      multiple
+    />
+  );
+};
 
 export default ProjectSearch;
 


### PR DESCRIPTION
## Description

The functionality was implemented, the UI is based on the search box in the Files view design. 

It is possible to search by tag or by title. Right now only the publications that match all search terms are shown, but it will be easy to change it to "match any term" or tie the behavior to a switch/checkbox if we decide it will be an improvement.  

The layout is somewhat resistant to excessive input, but more than 2-3 lines will look off. 

## Linked issues

Closes #183 

