### PR TITLE
Make paths formats more uniform

### DIFF
--- a/src/main/api/git/stage.ts
+++ b/src/main/api/git/stage.ts
@@ -4,6 +4,7 @@ import { mainStore as store } from 'src/main';
 import { activePublication } from '../../../shared/redux/slices/loadPublicationsSlice';
 import { LocalPublication } from '../../../shared/types';
 import { GitRepoTreeItem, IpcEventHandler } from '../../../shared/types/api';
+import { absoluteToGitPath } from '../../../shared/utils/paths';
 import { createLogger } from '../../logger';
 
 const stage: IpcEventHandler = async (
@@ -20,11 +21,12 @@ const stage: IpcEventHandler = async (
 
   await Promise.all(
     items.map(async (item) => {
+      const filepath = absoluteToGitPath(item.filepath, publication.dirPath);
       if (action === 'stage')
         await updateIndex({
           fs,
           dir: publication.dirPath,
-          filepath: item.filepath,
+          filepath,
           add: true,
           remove: !item.status.workdir,
         });
@@ -32,7 +34,7 @@ const stage: IpcEventHandler = async (
         await resetIndex({
           fs,
           dir: publication.dirPath,
-          filepath: item.filepath,
+          filepath,
         });
     })
   );

--- a/src/renderer/views/Files/Files.tsx
+++ b/src/renderer/views/Files/Files.tsx
@@ -76,13 +76,7 @@ const Files = () => {
             disabled={currentDirectory === project.dirPath}
           />
           <FileTreeItem
-            item={
-              findByPath(
-                RepoTree,
-                path.join(path.relative(project.dirPath, currentDirectory)),
-                { targetPathSeparator: path.sep }
-              ) || RepoTree
-            }
+            item={findByPath(RepoTree, currentDirectory) || RepoTree}
             treeLevel={0}
             dirPath={project.dirPath}
             notRendered

--- a/src/renderer/views/Files/subcomponents/FileTreeItem/FileTreeItem.tsx
+++ b/src/renderer/views/Files/subcomponents/FileTreeItem/FileTreeItem.tsx
@@ -1,4 +1,3 @@
-import path from 'path';
 import React from 'react';
 import { GitRepoTreeItem } from '../../../../../shared/types/api';
 import FileDisplay from '../../../../components/FileDisplay/FileDisplay';
@@ -12,10 +11,7 @@ interface Props {
 }
 
 const FileTreeItem = ({ item, treeLevel, dirPath, notRendered }: Props) => {
-  const nodeId = createNodeId(
-    path.join(dirPath, item.filepath),
-    item.isDirectory
-  );
+  const nodeId = createNodeId(item.filepath, item.isDirectory);
 
   if (notRendered) return <>{contentMap(item.children, treeLevel, dirPath)}</>;
 

--- a/src/shared/utils/paths.ts
+++ b/src/shared/utils/paths.ts
@@ -1,0 +1,9 @@
+import path from 'path';
+
+const GIT_PATH_DELIMITER = '/';
+
+export const gitPathToAbsolute = (relativePath: string, dirPath: string) =>
+  path.join(dirPath, ...relativePath.split(GIT_PATH_DELIMITER));
+
+export const absoluteToGitPath = (absolutePath: string, dirPath: string) =>
+  path.relative(dirPath, absolutePath).replaceAll(path.sep, GIT_PATH_DELIMITER);

--- a/src/shared/utils/repoStatus/tree.ts
+++ b/src/shared/utils/repoStatus/tree.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { GitRepoTreeItem } from '../../types/api';
 
 export function search(
@@ -14,12 +15,14 @@ export function search(
 export function findByPath(
   node: GitRepoTreeItem,
   targetPath: string,
-  { targetPathSeparator = '/', step = 0 } = {}
+  { targetPathSeparator = path.sep, step = 0 } = {}
 ): GitRepoTreeItem | undefined {
-  const target = targetPath.split(targetPathSeparator)[step];
-  if (target === undefined) return node;
+  const target = path
+    .relative(node.filepath, targetPath)
+    .split(targetPathSeparator)[0];
+  if (target === '') return node;
   const nextNode = node.children.find(
-    (child) => child.filepath.split('/')[step] === target
+    (child) => path.basename(child.filepath) === target
   );
   if (!nextNode) return undefined;
   return findByPath(nextNode, targetPath, {
@@ -31,12 +34,14 @@ export function findByPath(
 export function replaceChildNode(
   node: GitRepoTreeItem,
   payload: GitRepoTreeItem,
-  { targetPathSeparator = '/', step = 0 } = {}
+  { targetPathSeparator = path.sep, step = 0 } = {}
 ): GitRepoTreeItem | undefined {
-  const target = payload.filepath.split(targetPathSeparator)[step];
-  if (target === undefined) return payload;
+  const target = path
+    .relative(node.filepath, payload.filepath)
+    .split(targetPathSeparator)[0];
+  if (target === '') return payload;
   const nextNodeIndex = node.children.findIndex(
-    (child) => child.filepath.split('/')[step] === target
+    (child) => path.basename(child.filepath) === target
   );
   const nextNode = replaceChildNode(node.children[nextNodeIndex], payload, {
     targetPathSeparator,


### PR DESCRIPTION
## Description

Code was changed to use absolute, platform specific path format whenever possible. When utilizing `isomorphic-git`'s features, paths are converted back and forth using the two functions in `paths.ts`.

## Linked issues

Closes #219 
