### PR TITLE
Fix login screen styles

### DIFF
--- a/src/renderer/components/LoginComponent/LoginComponent.tsx
+++ b/src/renderer/components/LoginComponent/LoginComponent.tsx
@@ -25,7 +25,7 @@ const LoginComponent = () => {
 
   return (
     <ThemeProvider theme={altTheme}>
-      <Styled.ViewContent>
+      <Styled.ViewContent contentBoxProps={{ sx: { m: 0 } }}>
         <Styled.LangBox>
           {supportedLocales.map((locale) => (
             <Button

--- a/src/renderer/components/LoginComponent/style.ts
+++ b/src/renderer/components/LoginComponent/style.ts
@@ -18,6 +18,7 @@ export const LangBox = styled(Box)(({ theme }) => ({
     content: '"/"',
     fontSize: theme.typography.body1.fontSize,
   },
+  marginTop: theme.spacing(1),
 }));
 
 export const ContainerBox = styled(Box)(({ theme }) => ({
@@ -25,4 +26,5 @@ export const ContainerBox = styled(Box)(({ theme }) => ({
   flexDirection: 'column',
   alignItems: 'center',
   gap: theme.spacing(3),
+  margin: theme.spacing(2, 0),
 }));


### PR DESCRIPTION
## Description

- The view now fits within the viewport.
- Some additional margins have been given to elements to protect from being squashed on tiny wee viewports.

## Preview

![image](https://user-images.githubusercontent.com/34404855/181063008-25ad3bd3-f55c-4d95-980f-cf9d60d0dbee.png)



