### PR TITLE
Gatsby-config modification

### DIFF
--- a/src/main/api/publications/generate.ts
+++ b/src/main/api/publications/generate.ts
@@ -39,7 +39,7 @@ const generate: IpcEventHandler = async (_, params: PublicationBase) => {
     const packageHandler = createPackageHandler({ dirPath, name: repoName });
     store.dispatch(setStatus(STATUS.MODIFYING_PACKAGE_JSON));
     await packageHandler.modifyPackage((packageJSON) => {
-      packageJSON.name = name;
+      packageJSON.name = repoName;
       packageJSON.author = author;
       packageJSON.description = description;
     });

--- a/src/main/api/publications/updateConfig.ts
+++ b/src/main/api/publications/updateConfig.ts
@@ -1,7 +1,11 @@
+/* eslint-disable no-param-reassign */
+import path from 'path';
 import { IpcEventHandler } from 'src/shared/types/api';
 import createConfigFileHandler, {
   Config,
 } from '../../lib/configurationFileHandler';
+import createGatsbyConfigHandler from '../../lib/gatsbyConfigHandler';
+import createPackageHandler from '../../lib/packageHandler';
 
 const updateConfig: IpcEventHandler = async (
   _,
@@ -11,6 +15,33 @@ const updateConfig: IpcEventHandler = async (
   const configHandler = createConfigFileHandler({ dirPath });
   const oldConfig = await configHandler.getConfig();
   await configHandler.setConfig({ ...oldConfig, ...changes });
+
+  if (changes.name || changes.description) {
+    const options = {
+      name: path.basename(dirPath),
+      dirPath: path.dirname(dirPath),
+      usesTypescript: oldConfig.useTypescript,
+    };
+    const gatsbyConfigHandler = createGatsbyConfigHandler(options);
+    await gatsbyConfigHandler.modifyConfig((originalData) => {
+      let data = originalData;
+      if (changes.name)
+        data = data.replace(/title: `(.*?)`,/g, `title: \`${changes.name}\`,`);
+      if (changes.description)
+        data = data.replace(
+          /description: `.*?`,/g,
+          `description: \`${changes.description}\`,`
+        );
+      return data;
+    });
+
+    const packageHandler = createPackageHandler(options);
+    await packageHandler.modifyPackage((packageJSON) => {
+      if (changes.name)
+        packageJSON.name = changes.name.toLowerCase().replaceAll(' ', '-');
+      if (changes.description) packageJSON.description = changes.description;
+    });
+  }
 };
 
 export default updateConfig;

--- a/src/main/lib/gatsbyConfigHandler.ts
+++ b/src/main/lib/gatsbyConfigHandler.ts
@@ -6,6 +6,7 @@ export interface GatsbyConfigHandler {
   getConfig: () => Promise<string>;
   setConfig: (config: string) => Promise<void>;
   modifyConfig: (modifier: (config: string) => string) => Promise<void>;
+  getPath: () => string;
 }
 
 const createGatsbyConfigHandler = (options: {
@@ -56,6 +57,9 @@ const createGatsbyConfigHandler = (options: {
         logger.appendError(`${error}`);
         throw new Error(error.message);
       }
+    },
+    getPath() {
+      return gatsbyConfigPath;
     },
   };
 };

--- a/src/renderer/views/Settings/Settings.tsx
+++ b/src/renderer/views/Settings/Settings.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material';
 import React, { useReducer, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { v4 as uuidv4 } from 'uuid';
 import {
   activePublication,
   updatePublication,
@@ -13,10 +14,11 @@ import ViewContent from '../../components/ViewContent/ViewContent';
 import Button from '../../components/Button/Button';
 import { LocalPublication } from '../../../shared/types';
 import { Config } from '../../../main/lib/configurationFileHandler';
-import { updateConfig } from '../../ipc';
+import { gitCommit, gitPush, updateConfig } from '../../ipc';
 import { sendNotification } from '../../../shared/redux/slices/notificationsSlice';
 import TagsManager from './subcomponents/TagsManager/TagsManager';
 import SnippetsManager from './subcomponents/SnippetsManager/SnippetsManager';
+import LoaderOverlay from '../../components/LoaderOverlay/LoaderOverlay';
 
 const Settings = () => {
   const { t } = useTranslation();
@@ -30,70 +32,78 @@ const Settings = () => {
     {}
   );
   const [canSubmit, setCanSubmit] = useState(true);
+  const [loaderId, setLoaderID] = useState('');
 
   const projectSettings = { ...project, ...changes };
 
   return (
-    <ViewContent>
-      <Typography variant='h1' mb={4}>
-        {projectSettings.name}
-      </Typography>
-      <SeparatedSection pb={3}>
-        <ProjectDetailsInput
-          state={projectSettings}
-          onSubmit={handleChange}
-          onValidationStateChange={setCanSubmit}
-        />
-      </SeparatedSection>
-      <SeparatedSection pb={3}>
-        <TagsManager state={projectSettings} onSubmit={handleChange} />
-      </SeparatedSection>
-      <SeparatedSection pb={3}>
-        <CollaboratorsPicker
-          state={projectSettings}
-          compact
-          onAdd={(collaborator) =>
-            handleChange({
-              collaborators: [...projectSettings.collaborators, collaborator],
-            })
-          }
-          onDelete={(id) =>
-            handleChange({
-              collaborators: projectSettings.collaborators.filter(
-                (collaborator) => !(collaborator.id === id)
-              ),
-            })
-          }
-        />
-      </SeparatedSection>
-      <SeparatedSection pb={3}>
-        <SnippetsManager state={projectSettings} onSubmit={handleChange} />
-      </SeparatedSection>
-      <SeparatedSection pb={3}>
-        <Button
-          variant='contained'
-          color='green'
-          sx={{ m: 0 }}
-          isMajor
-          fullWidth
-          disabled={!canSubmit}
-          onClick={() => {
-            updateConfig(project.dirPath, changes);
-            dispatch(updatePublication({ ...project, ...changes }));
-            dispatch(
-              sendNotification({
-                title: t('ProjectSettings.notification.title'),
-                message: t('ProjectSettings.notification.message'),
-                type: 'success',
-                autoDismiss: true,
+    <>
+      <ViewContent>
+        <Typography variant='h1' mb={4}>
+          {projectSettings.name}
+        </Typography>
+        <SeparatedSection pb={3}>
+          <ProjectDetailsInput
+            state={projectSettings}
+            onSubmit={handleChange}
+            onValidationStateChange={setCanSubmit}
+          />
+        </SeparatedSection>
+        <SeparatedSection pb={3}>
+          <TagsManager state={projectSettings} onSubmit={handleChange} />
+        </SeparatedSection>
+        <SeparatedSection pb={3}>
+          <CollaboratorsPicker
+            state={projectSettings}
+            compact
+            onAdd={(collaborator) =>
+              handleChange({
+                collaborators: [...projectSettings.collaborators, collaborator],
               })
-            );
-          }}
-        >
-          {t('common.save')}
-        </Button>
-      </SeparatedSection>
-    </ViewContent>
+            }
+            onDelete={(id) =>
+              handleChange({
+                collaborators: projectSettings.collaborators.filter(
+                  (collaborator) => !(collaborator.id === id)
+                ),
+              })
+            }
+          />
+        </SeparatedSection>
+        <SeparatedSection pb={3}>
+          <SnippetsManager state={projectSettings} onSubmit={handleChange} />
+        </SeparatedSection>
+        <SeparatedSection pb={3}>
+          <Button
+            variant='contained'
+            color='green'
+            sx={{ m: 0 }}
+            isMajor
+            fullWidth
+            disabled={!canSubmit}
+            onClick={async () => {
+              const id = uuidv4();
+              setLoaderID(id);
+              await updateConfig(project.dirPath, changes);
+              await gitCommit('config changes');
+              await gitPush(id);
+              dispatch(updatePublication({ ...project, ...changes }));
+              dispatch(
+                sendNotification({
+                  title: t('ProjectSettings.notification.title'),
+                  message: t('ProjectSettings.notification.message'),
+                  type: 'success',
+                  autoDismiss: true,
+                })
+              );
+            }}
+          >
+            {t('common.save')}
+          </Button>
+        </SeparatedSection>
+      </ViewContent>
+      <LoaderOverlay id={loaderId} />
+    </>
   );
 };
 

--- a/src/renderer/views/Settings/Settings.tsx
+++ b/src/renderer/views/Settings/Settings.tsx
@@ -85,7 +85,7 @@ const Settings = () => {
               const id = uuidv4();
               setLoaderID(id);
               await updateConfig(project.dirPath, changes);
-              await gitCommit('Config update\n\n[publAB automatic commit]');
+              await gitCommit('Config update\n\n[PubLab automatic commit]');
               await gitPush(id);
               dispatch(updatePublication({ ...project, ...changes }));
               dispatch(

--- a/src/renderer/views/Settings/Settings.tsx
+++ b/src/renderer/views/Settings/Settings.tsx
@@ -85,7 +85,7 @@ const Settings = () => {
               const id = uuidv4();
               setLoaderID(id);
               await updateConfig(project.dirPath, changes);
-              await gitCommit('config changes');
+              await gitCommit('Config update\n\n[publAB automatic commit]');
               await gitPush(id);
               dispatch(updatePublication({ ...project, ...changes }));
               dispatch(


### PR DESCRIPTION
## Description

Now config changes are also reflected in `gatsby-config`. Additionaly, publication `package.json` is updated too.

Changed files will be immediately commited and pushed to the remote. 

## Preview

![electron_MIrwOLbMh2](https://user-images.githubusercontent.com/23729453/181120838-22668b90-3309-45e5-b5f4-19e737cf6323.gif)


## Linked issues

e.g. closes #223 

