### PR TITLE
Guard repo fetch if token is not present

### DIFF
--- a/src/main/lib/publicationFinder.ts
+++ b/src/main/lib/publicationFinder.ts
@@ -78,9 +78,11 @@ const createPublicationFinder = (): PublicationFinder => {
       const token = store.getState().currentUser.auth.accessToken?.value;
       const { appSettings } = store.getState();
       const { syncLocations } = appSettings;
+      const publications: Publication[] = [];
+
+      if (!token) return publications;
 
       const { repos } = new Octokit({ auth: token }).rest;
-      const publications: Publication[] = [];
 
       const repositoryPromises = syncLocations
         .filter(({ enabled }) => enabled)

--- a/src/shared/redux/helpers/utilSelectors.ts
+++ b/src/shared/redux/helpers/utilSelectors.ts
@@ -1,0 +1,15 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { selectCurrentUser } from '../slices/currentUserSlice';
+import { selectDefaultDirPath } from '../slices/settingsSlice';
+
+export const selectReadPublicationsOptions = createSelector<
+  [typeof selectDefaultDirPath, typeof selectCurrentUser],
+  { findLocal: boolean; findRemote: boolean }
+>([selectDefaultDirPath, selectCurrentUser], (path, { auth }) => {
+  const isTokenValid = !!auth.accessToken?.value;
+
+  return {
+    findLocal: isTokenValid && !!path,
+    findRemote: isTokenValid,
+  };
+});


### PR DESCRIPTION
## Description

Guard to not fetch remote publications when the token is missing has been put in place.

## Linked issues

Fixes #229

