### PR TITLE
Support for polish letters in `publab.config.json`

### DIFF
--- a/src/main/lib/publicationFinder.ts
+++ b/src/main/lib/publicationFinder.ts
@@ -113,9 +113,8 @@ const createPublicationFinder = (): PublicationFinder => {
 
               if ('content' in contents && contents.encoding === 'base64') {
                 const buffer = Buffer.from(contents.content, contents.encoding);
-                const decoded = buffer.toString('ascii');
+                const decoded = buffer.toString('utf-8');
                 const config: Config = JSON.parse(decoded);
-                // TODO: handle the last update parameter
                 publications.push({
                   ...config,
                   status: 'remote',


### PR DESCRIPTION
## Description

With UTF-8 we support polish letter in the config file. Previosuly this resulted in https://github.com/vnLab-Lodz/odszkolnic_web failing to register as a remote publication in the app.

@LostInStatic not much to review here but would be grand if you could check if "Odszkolnić! Deschool!" shows up in your publications list now.

## Linked issues

Closes #247 