### PR TITLE
Switch branch based on logged in user

### DIFF
--- a/src/main/api/git/checkout.ts
+++ b/src/main/api/git/checkout.ts
@@ -1,0 +1,48 @@
+import { mainStore as store } from 'src/main';
+import { MAIN_BRANCH } from '../../../shared/constants';
+import { selectCurrentUserData } from '../../../shared/redux/slices/currentUserSlice';
+import { activePublication } from '../../../shared/redux/slices/loadPublicationsSlice';
+import { selectRepoTree } from '../../../shared/redux/slices/repoStatusSlice';
+import { LocalPublication, USER_ROLES } from '../../../shared/types';
+import { IpcEventHandler } from '../../../shared/types/api';
+import { isChanged } from '../../../shared/utils/repoStatus/statusChecks';
+import { search as repoTreeSearch } from '../../../shared/utils/repoStatus/tree';
+import createGitRepoHandler from '../../lib/gitRepoHandler';
+import { createLogger } from '../../logger';
+
+const checkout: IpcEventHandler = async () => {
+  console.log('run');
+  const logger = createLogger();
+  const storeState = store.getState();
+  const publication = activePublication(storeState) as LocalPublication;
+  const repoHandler = createGitRepoHandler(publication);
+  const user = selectCurrentUserData(storeState);
+  const repoTree = selectRepoTree(storeState);
+  if (!user) {
+    logger.appendError('No user is logged in!');
+    return;
+  }
+
+  if (!repoTree) {
+    logger.appendError('No repo tree initialised!');
+    return;
+  }
+  const changes = repoTreeSearch(repoTree, (node) => isChanged(node.status));
+
+  if (changes) {
+    await repoHandler.commit({
+      message:
+        'WIP\n\n[PubLab automatic commit]\nThis commit was created by PubLab to prevent data loss when switching branches.',
+      authorUsername: user.nick,
+    });
+  }
+
+  const userRole = publication.collaborators.find(
+    (collaborator) => user.nick === collaborator.githubUsername
+  )?.role;
+
+  await repoHandler.checkout(
+    userRole === USER_ROLES.EDITOR ? `editor-${user.nick}` : MAIN_BRANCH
+  );
+};
+export default checkout;

--- a/src/main/api/git/clone.ts
+++ b/src/main/api/git/clone.ts
@@ -17,6 +17,7 @@ import {
   removeLoader,
 } from 'src/shared/redux/slices/loadersSlice';
 
+// TODO: probably this also should be moved to src\main\lib\gitRepoHandler.ts
 interface Options {
   loaderId: string;
 }

--- a/src/main/api/git/commit.ts
+++ b/src/main/api/git/commit.ts
@@ -1,30 +1,22 @@
-import fs from 'fs';
-import { commit as gitCommit } from 'isomorphic-git';
 import { mainStore as store } from 'src/main';
 import { selectCurrentUserData } from '../../../shared/redux/slices/currentUserSlice';
 import { activePublication } from '../../../shared/redux/slices/loadPublicationsSlice';
 import { LocalPublication } from '../../../shared/types';
 import { IpcEventHandler } from '../../../shared/types/api';
+import createGitRepoHandler from '../../lib/gitRepoHandler';
 import { createLogger } from '../../logger';
 
 const commit: IpcEventHandler = async (_, message: string) => {
   const logger = createLogger();
   const publication = activePublication(store.getState()) as LocalPublication;
   const user = selectCurrentUserData(store.getState());
-  if (!publication?.dirPath) {
-    logger.appendError('No active publication or directory path is undefined');
-    return;
-  }
+  const repoHandler = createGitRepoHandler(publication);
+
   if (!user) {
     logger.appendError('No user is logged in!');
     return;
   }
-  await gitCommit({
-    fs,
-    dir: publication.dirPath,
-    message,
-    author: { name: user.nick },
-  });
+  await repoHandler.commit({ message, authorUsername: user.nick });
 };
 
 export default commit;

--- a/src/main/api/git/status.ts
+++ b/src/main/api/git/status.ts
@@ -25,6 +25,8 @@ import {
   gitPathToAbsolute,
 } from '../../../shared/utils/paths';
 
+// TODO: probably this also should be moved to src\main\lib\gitRepoHandler.ts
+
 export const updateRepoStatus: IpcEventHandler = async () => {
   const logger = createLogger();
   const publication = activePublication(store.getState()) as LocalPublication;

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -23,6 +23,7 @@ import copyFile from './files/copyFile';
 import removeFile from './files/removeFile';
 import getPublicUserData from './gitHub/getPublicUserData';
 import updateCollaborators from './gitHub/updateCollaborators';
+import checkout from './git/checkout';
 import start from './server/start';
 import clearCache from './server/clearCache';
 
@@ -49,6 +50,7 @@ const registerApiHandlers = () => {
   ipc.handle(CHANNELS.GIT.FILES_STATUS, updateFilesStatus);
   ipc.handle(CHANNELS.GIT.STAGE, stage);
   ipc.handle(CHANNELS.GIT.COMMIT, commit);
+  ipc.handle(CHANNELS.GIT.CHECKOUT, checkout);
   ipc.handle(CHANNELS.GITHUB.GET_USER_PUBLIC, getPublicUserData);
   ipc.handle(CHANNELS.GITHUB.UPDATE_COLLABORATORS, updateCollaborators);
   ipc.handle(CHANNELS.SERVER.START, start);

--- a/src/main/lib/gitRepoHandler.ts
+++ b/src/main/lib/gitRepoHandler.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import http from 'isomorphic-git/http/node';
+import * as git from 'isomorphic-git';
+import { LocalPublication } from '../../shared/types';
+import { createLogger } from '../logger';
+import { GitRepoTreeItem } from '../../shared/types/api';
+import { absoluteToGitPath } from '../../shared/utils/paths';
+
+const createGitRepoHandler = (publication: LocalPublication) => {
+  const logger = createLogger();
+
+  if (!publication.dirPath) {
+    const msg = 'No active publication or directory path is undefined';
+    logger.appendError(msg);
+    throw new Error(msg);
+  }
+
+  return {
+    commit: async ({
+      message,
+      authorUsername,
+    }: {
+      message: string;
+      authorUsername: string;
+    }) => {
+      await git.commit({
+        fs,
+        dir: publication.dirPath,
+        message,
+        author: { name: authorUsername },
+      });
+    },
+
+    push: async ({
+      authToken,
+      remoteRef,
+      onAuthFailure,
+    }: {
+      authToken: string;
+      remoteRef?: string;
+      onAuthFailure?: git.AuthFailureCallback;
+    }) => {
+      await git.push({
+        fs,
+        http,
+        dir: publication.dirPath,
+        remoteRef,
+        onAuth: () => ({ username: authToken }), // https://isomorphic-git.org/docs/en/onAuth
+        onAuthFailure,
+      });
+    },
+
+    stage: async (items: GitRepoTreeItem[]) => {
+      await Promise.all(
+        items.map(async (item) => {
+          const filepath = absoluteToGitPath(
+            item.filepath,
+            publication.dirPath
+          );
+          await git.updateIndex({
+            fs,
+            dir: publication.dirPath,
+            filepath,
+            add: true,
+            remove: !item.status.workdir,
+          });
+        })
+      );
+    },
+
+    unstage: async (items: GitRepoTreeItem[]) => {
+      await Promise.all(
+        items.map(async (item) => {
+          const filepath = absoluteToGitPath(
+            item.filepath,
+            publication.dirPath
+          );
+          await git.resetIndex({
+            fs,
+            dir: publication.dirPath,
+            filepath,
+          });
+        })
+      );
+    },
+
+};
+
+export default createGitRepoHandler;

--- a/src/main/lib/gitRepoHandler.ts
+++ b/src/main/lib/gitRepoHandler.ts
@@ -5,6 +5,7 @@ import { LocalPublication } from '../../shared/types';
 import { createLogger } from '../logger';
 import { GitRepoTreeItem } from '../../shared/types/api';
 import { absoluteToGitPath } from '../../shared/utils/paths';
+import { MAIN_BRANCH } from '../../shared/constants';
 
 const createGitRepoHandler = (publication: LocalPublication) => {
   const logger = createLogger();
@@ -94,6 +95,11 @@ const createGitRepoHandler = (publication: LocalPublication) => {
       } catch (e) {
         if ((e as any).code === 'NotFoundError') {
           logger.appendLog(`${(e as Error).message} 'Creating new branch.`);
+          await git.checkout({
+            fs,
+            dir: publication.dirPath,
+            ref: MAIN_BRANCH,
+          });
           await git.branch({
             fs,
             dir: publication.dirPath,

--- a/src/main/lib/gitRepoHandler.ts
+++ b/src/main/lib/gitRepoHandler.ts
@@ -84,6 +84,26 @@ const createGitRepoHandler = (publication: LocalPublication) => {
       );
     },
 
+    checkout: async (branch: string) => {
+      try {
+        await git.checkout({
+          fs,
+          dir: publication.dirPath,
+          ref: branch,
+        });
+      } catch (e) {
+        if ((e as any).code === 'NotFoundError') {
+          logger.appendLog(`${(e as Error).message} 'Creating new branch.`);
+          await git.branch({
+            fs,
+            dir: publication.dirPath,
+            ref: branch,
+            checkout: true,
+          });
+        }
+      }
+    },
+  };
 };
 
 export default createGitRepoHandler;

--- a/src/renderer/views/ProjectsList/subcomponents/ProjectsTable/ProjectsTable.tsx
+++ b/src/renderer/views/ProjectsList/subcomponents/ProjectsTable/ProjectsTable.tsx
@@ -54,7 +54,8 @@ const ProjectTable: React.FC<Props> = ({ publications }) => {
       );
     }
     dispatch(setActivePublication(publication.id));
-    ipcRenderer.invoke(CHANNELS.GIT.REPO_STATUS);
+    await ipcRenderer.invoke(CHANNELS.GIT.REPO_STATUS);
+    await ipcRenderer.invoke(CHANNELS.GIT.CHECKOUT);
     dispatch(updateCurrentView(VIEWS.PROJECT));
   };
 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -68,6 +68,7 @@ export const CHANNELS = {
     FILES_STATUS: 'git:files-status',
     STAGE: 'git:stage',
     COMMIT: 'git:commit',
+    CHECKOUT: 'git:checkout',
   },
   GITHUB: {
     GET_USER_PUBLIC: 'github:get-user-public',


### PR DESCRIPTION
## Description

When a publication is activated, checked out branch will depend on logged in user. If user's role is developer, `main` will be checked out, if it is editor, their corresponding `editor-USERNAME` branch is checked out, Any changes left on the previous branch will be commited as a "WIP" commit. If the branch with that name is not present, it will be created off `main`.

Additionaly, some `isomorphic-git` usage was refactored into a new handler, mostly to avoid code repetition by providing defaults and error handling. Some code was not updated in this way because of its complexity - would rather avoid touching that without a planned refactor.
