### PR TITLE
Project creation based on templates

### DIFF
--- a/.storybook/__mocks__/fs.js
+++ b/.storybook/__mocks__/fs.js
@@ -1,0 +1,1 @@
+export const readFile = async () => '';

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -9,6 +11,8 @@ module.exports = {
     delete config.resolve.alias['emotion-theming'];
     delete config.resolve.alias['@emotion/styled'];
     delete config.resolve.alias['@emotion/core'];
+    config.resolve.alias['fs'] = require.resolve('./__mocks__/fs.js');
+    config.resolve.plugins.push(new TsconfigPathsPlugin());
     return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "sass-loader": "^10.0.3",
     "style-loader": "^1.2.1",
     "ts-loader": "^8.0.2",
+    "tsconfig-paths-webpack-plugin": "^4.0.0",
     "typescript": "^4.0.2"
   },
   "dependencies": {

--- a/src/main/api/publications/generate.ts
+++ b/src/main/api/publications/generate.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import http from 'isomorphic-git/http/node';
 import { createLogger } from 'src/main/logger';
 import { mainStore as store } from 'src/main';
-import { PublicationBase, USER_ROLES } from 'src/shared/types';
+import { PublicationBase } from 'src/shared/types';
 import { IpcEventHandler } from 'src/shared/types/api';
 import createAuthorFromCollaborators from 'src/shared/utils/createAuthorFromCollaborators';
 import createGatsbyProjectGenerator from 'src/main/lib/gatsbyProjectGenerator';
@@ -23,6 +23,7 @@ import {
 } from 'src/shared/redux/slices/loadPublicationsSlice';
 import path from 'path';
 import git from 'isomorphic-git';
+import { AddPublicationWizard } from 'src/shared/redux/slices/addPublicationWizardSlice';
 import {
   CONFIG_NAME,
   COVER_PIC_FILENAME,
@@ -32,7 +33,10 @@ import {
 import createFileIO from '../../lib/fileIO';
 import createGitHubHandler from '../../lib/gitHubHandler';
 
-const generate: IpcEventHandler = async (_, params: PublicationBase) => {
+const generate: IpcEventHandler = async (
+  _,
+  params: AddPublicationWizard['data']
+) => {
   const logger = createLogger();
 
   try {

--- a/src/main/lib/gatsbyProjectGenerator.ts
+++ b/src/main/lib/gatsbyProjectGenerator.ts
@@ -1,6 +1,6 @@
-import { PublicationBase } from 'src/shared/types';
 import child_process from 'child_process';
 import util from 'util';
+import { AddPublicationWizard } from 'src/shared/redux/slices/addPublicationWizardSlice';
 import { createLogger } from '../logger';
 
 const exec = util.promisify(child_process.exec);
@@ -8,6 +8,7 @@ const exec = util.promisify(child_process.exec);
 export enum TEMPLATE_URLS {
   PAAW_I18N = 'https://github.com/vnLab-Lodz/gatsby-starter-paaw-i18n',
   PAAW_BASIC = 'https://github.com/vnLab-Lodz/gatsby-starter-paaw-basic',
+  PAAW_SASS = 'https://github.com/vnLab-Lodz/gatsby-starter-paaw-sass',
 }
 
 export interface GatsbyProjectGenerator {
@@ -16,14 +17,13 @@ export interface GatsbyProjectGenerator {
 }
 
 const createGatsbyProjectGenerator = (
-  publication: PublicationBase
+  publication: AddPublicationWizard['data']
 ): GatsbyProjectGenerator => ({
   getTemplateUrl() {
-    const { useSass, useTypescript } = publication;
+    const { useSass, multilingual } = publication;
+    if (multilingual) return TEMPLATE_URLS.PAAW_I18N;
 
-    return useSass && useTypescript
-      ? TEMPLATE_URLS.PAAW_I18N
-      : TEMPLATE_URLS.PAAW_BASIC;
+    return useSass ? TEMPLATE_URLS.PAAW_SASS : TEMPLATE_URLS.PAAW_BASIC;
   },
   async generate(cwd, repoName = publication.name) {
     const logger = createLogger();

--- a/src/renderer/components/CollabPicker/CollabPicker.stories.tsx
+++ b/src/renderer/components/CollabPicker/CollabPicker.stories.tsx
@@ -18,6 +18,7 @@ const Template: ComponentStory<typeof CollabPicker> = (args) => (
 export const Default = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Default.args = {
+  value: { username: 'Test user', role: 'developer' },
   buttonText: 'Add',
   selectPlaceholder: 'Role',
   textFieldPlaceholder: 'Username...',

--- a/src/renderer/components/Languages/LanguagesPicker.tsx
+++ b/src/renderer/components/Languages/LanguagesPicker.tsx
@@ -1,0 +1,62 @@
+import { Box, RadioGroup, Typography } from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AddPublicationWizard } from 'src/shared/redux/slices/addPublicationWizardSlice';
+import RadioBtn, { RadioFormControl } from '../RadioButton/RadioBtn';
+
+type State = Pick<AddPublicationWizard['data'], 'multilingual'>;
+
+interface Props {
+  onSubmit: (state: State) => void;
+  state: State;
+}
+
+const LanguagesPicker = ({ onSubmit, state }: Props) => {
+  const { t } = useTranslation();
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value === 'multi';
+    onSubmit({ ...state, multilingual: value });
+  };
+
+  const value = state.multilingual ? 'multi' : 'single';
+
+  return (
+    <Box>
+      <Typography variant='subtitle1' component='p' mb={3}>
+        {t('AddProject.LanguagesPicker.message')}
+      </Typography>
+
+      <Box mb={2}>
+        <RadioGroup value={value} onChange={handleChange}>
+          <RadioFormControl
+            value='single'
+            control={<RadioBtn />}
+            label={
+              <Typography
+                variant='body2'
+                style={{ textTransform: 'uppercase' }}
+              >
+                {t('AddProject.LanguagesPicker.single')}
+              </Typography>
+            }
+          />
+          <RadioFormControl
+            value='multi'
+            control={<RadioBtn />}
+            label={
+              <Typography
+                variant='body2'
+                style={{ textTransform: 'uppercase' }}
+              >
+                {t('AddProject.LanguagesPicker.multi')}
+              </Typography>
+            }
+          />
+        </RadioGroup>
+      </Box>
+    </Box>
+  );
+};
+
+export default LanguagesPicker;

--- a/src/renderer/components/Notification/Notification.stories.tsx
+++ b/src/renderer/components/Notification/Notification.stories.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Provider } from 'react-redux';
+import notificationsSlice from 'src/shared/redux/slices/notificationsSlice';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import Notification, {
   NotificationText,
   NotificationTitle,
@@ -13,7 +16,13 @@ export default {
 } as ComponentMeta<typeof Notification>;
 
 const Template: ComponentStory<typeof Notification> = (args) => (
-  <Notification {...args} />
+  <Provider
+    store={configureStore({
+      reducer: combineReducers({ notifications: notificationsSlice }),
+    })}
+  >
+    <Notification {...args} />
+  </Provider>
 );
 
 const children = (
@@ -26,7 +35,7 @@ const children = (
 );
 
 export const Blank = Template.bind({});
-Blank.args = { type: NOTIFICATION_TYPES.INFO };
+Blank.args = { type: NOTIFICATION_TYPES.INFO, children };
 
 export const Info = Template.bind({});
 Info.args = { type: NOTIFICATION_TYPES.INFO, children };

--- a/src/renderer/components/PackageManagerPicker/PackageManagerPicker.tsx
+++ b/src/renderer/components/PackageManagerPicker/PackageManagerPicker.tsx
@@ -1,8 +1,9 @@
-import { Box, FormControlLabel, RadioGroup, Typography } from '@mui/material';
+import { Box, RadioGroup, Typography } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Publication, PublicationBase } from 'src/shared/types';
-import RadioBtn from '../RadioButton/RadioBtn';
+import RadioBtn, { RadioFormControl } from '../RadioButton/RadioBtn';
+import Tooltip from '../Tooltip/Tooltip';
 
 type State = Pick<Publication, 'packageManager'>;
 
@@ -27,17 +28,23 @@ const PackageManagerPicker = ({ onSubmit, state }: Props) => {
 
       <Box mb={2}>
         <RadioGroup defaultValue={state.packageManager} onChange={handleChange}>
-          <FormControlLabel
+          <RadioFormControl
             value='npm'
             control={<RadioBtn />}
             label={<Typography variant='body2'>NPM</Typography>}
           />
-          <FormControlLabel
-            disabled
-            value='yarn'
-            control={<RadioBtn />}
-            label={<Typography variant='body2'>YARN</Typography>}
-          />
+          <Tooltip
+            title={t('AddProject.PackageManager.yarn-tooltip')}
+            arrow
+            placement='top-start'
+          >
+            <RadioFormControl
+              disabled
+              value='yarn'
+              control={<RadioBtn />}
+              label={<Typography variant='body2'>YARN</Typography>}
+            />
+          </Tooltip>
         </RadioGroup>
       </Box>
     </Box>

--- a/src/renderer/components/RadioButton/RadioBtn.tsx
+++ b/src/renderer/components/RadioButton/RadioBtn.tsx
@@ -1,5 +1,14 @@
 import { styled } from '@mui/material/styles';
 import Radio from '@mui/material/Radio';
+import { FormControlLabel } from '@mui/material';
+
+export const RadioFormControl = styled(FormControlLabel)(({ theme }) => ({
+  width: 'fit-content',
+
+  '&.Mui-disabled': {
+    color: theme.palette.text.disabled,
+  },
+}));
 
 const RadioBtn = styled(Radio)(({ theme }) => ({
   color: theme.palette.primary.main,
@@ -7,6 +16,9 @@ const RadioBtn = styled(Radio)(({ theme }) => ({
     color: theme.palette.primary.main,
   },
   '&.Mui-disabled': {
+    color: theme.palette.text.disabled,
+  },
+  '.MuiFormControlLabel-label': {
     color: theme.palette.text.disabled,
   },
 }));

--- a/src/renderer/components/RadioButton/RadioGroup.stories.tsx
+++ b/src/renderer/components/RadioButton/RadioGroup.stories.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import { Box, Typography } from '@mui/material';
-import RadioBtn from './RadioBtn';
+import RadioBtn, { RadioFormControl } from './RadioBtn';
 
 interface Props {
   disabled1?: boolean;
@@ -23,7 +22,7 @@ const RadioForm: React.FC<Props> = ({ disabled1, disabled2, defaults }) => (
       </FormLabel>
     </Box>
     <RadioGroup defaultValue={defaults} name='customized-radios'>
-      <FormControlLabel
+      <RadioFormControl
         disabled={disabled1}
         value='yarn'
         control={<RadioBtn />}
@@ -33,7 +32,7 @@ const RadioForm: React.FC<Props> = ({ disabled1, disabled2, defaults }) => (
           </Typography>
         }
       />
-      <FormControlLabel
+      <RadioFormControl
         disabled={disabled2}
         value='npm'
         control={<RadioBtn />}

--- a/src/renderer/components/Switch/Switch.stories.tsx
+++ b/src/renderer/components/Switch/Switch.stories.tsx
@@ -14,5 +14,5 @@ Normal.args = { disabled: false };
 Normal.parameters = { backgrounds: { default: 'dark' } };
 
 export const Disabled = Template.bind({});
-Disabled.args = { disabled: true };
+Disabled.args = { disabled: true, checked: true };
 Disabled.parameters = { backgrounds: { default: 'dark' } };

--- a/src/renderer/components/Switch/Switch.tsx
+++ b/src/renderer/components/Switch/Switch.tsx
@@ -1,7 +1,7 @@
 import Switch from '@mui/material/Switch';
 import { styled } from '@mui/material';
 
-const StyledSwitch = styled(Switch)(({ theme, size }) => ({
+const StyledSwitch = styled(Switch)(({ theme, size, disabled }) => ({
   width: size === 'small' ? '4rem' : '6rem',
   height: size === 'small' ? '2.4rem' : '3rem',
   padding: 0,
@@ -14,14 +14,15 @@ const StyledSwitch = styled(Switch)(({ theme, size }) => ({
     '&.Mui-checked': {
       transform: size === 'small' ? 'translate(16px)' : 'translateX(150%)',
       '& + .MuiSwitch-track': {
-        backgroundColor: theme.palette.green.main,
+        backgroundColor: disabled ? '#002f23' : theme.palette.green.main,
         opacity: 1,
       },
     },
   },
 
   '& .MuiSwitch-thumb': {
-    color: theme.palette.primary.main,
+    color: disabled ? theme.palette.text.disabled : theme.palette.primary.main,
+    opacity: disabled ? 1 : 1,
     width: size === 'small' ? '1.6rem' : '2rem',
     height: size === 'small' ? '1.6rem' : '2rem',
   },
@@ -29,8 +30,10 @@ const StyledSwitch = styled(Switch)(({ theme, size }) => ({
   '& .MuiSwitch-track': {
     borderRadius: '2rem',
     backgroundColor: 'transparent',
-    opacity: 1,
-    border: `1px solid ${theme.palette.primary.main}`,
+    border: `1px solid ${
+      disabled ? theme.palette.text.disabled : theme.palette.primary.main
+    }`,
+    opacity: disabled ? 1 : 1,
   },
 }));
 

--- a/src/renderer/components/TechnologiesPicker/TechnologiesPicker.tsx
+++ b/src/renderer/components/TechnologiesPicker/TechnologiesPicker.tsx
@@ -1,11 +1,14 @@
 import { Box, Typography } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Publication } from '../../../shared/types';
+import { AddPublicationWizard } from 'src/shared/redux/slices/addPublicationWizardSlice';
 import StyledSwitch from '../Switch/Switch';
 import Tooltip from '../Tooltip/Tooltip';
 
-type State = Pick<Publication, 'useSass' | 'useTypescript'>;
+type State = Pick<
+  AddPublicationWizard['data'],
+  'useSass' | 'useTypescript' | 'multilingual'
+>;
 
 interface Props {
   onSubmit: (state: State) => void;
@@ -15,9 +18,16 @@ interface Props {
 const TechnologiesPicker = ({ onSubmit, state }: Props) => {
   const { t } = useTranslation();
 
+  const sassTooltip = state.multilingual
+    ? t('technology-picker.sass-tooltip')
+    : '';
+
+  const sassLabelColor = state.multilingual ? 'gray.dark' : undefined;
+
   const toggleSass = () => {
     onSubmit({ ...state, useSass: !state.useSass });
   };
+
   const toggleTypescript = () => {
     onSubmit({ ...state, useTypescript: !state.useTypescript });
   };
@@ -30,14 +40,19 @@ const TechnologiesPicker = ({ onSubmit, state }: Props) => {
 
       <Box>
         <Box mb={2}>
-          <StyledSwitch
-            size='small'
-            checked={state.useSass}
-            onChange={toggleSass}
-          />
-          <Typography variant='body2' ml={1}>
-            SCSS
-          </Typography>
+          <Tooltip title={sassTooltip} arrow placement='top-start'>
+            <span>
+              <StyledSwitch
+                size='small'
+                checked={state.multilingual || state.useSass}
+                onChange={toggleSass}
+                disabled={state.multilingual}
+              />
+              <Typography variant='body2' ml={1} color={sassLabelColor}>
+                SCSS
+              </Typography>
+            </span>
+          </Tooltip>
         </Box>
         <Box>
           <Tooltip

--- a/src/renderer/components/TechnologiesPicker/TechnologiesPicker.tsx
+++ b/src/renderer/components/TechnologiesPicker/TechnologiesPicker.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Publication } from '../../../shared/types';
 import StyledSwitch from '../Switch/Switch';
+import Tooltip from '../Tooltip/Tooltip';
 
 type State = Pick<Publication, 'useSass' | 'useTypescript'>;
 
@@ -39,14 +40,23 @@ const TechnologiesPicker = ({ onSubmit, state }: Props) => {
           </Typography>
         </Box>
         <Box>
-          <StyledSwitch
-            size='small'
-            checked={state.useTypescript}
-            onChange={toggleTypescript}
-          />
-          <Typography variant='body2' ml={1}>
-            TYPESCRIPT
-          </Typography>
+          <Tooltip
+            title={t('technology-picker.ts-tooltip')}
+            arrow
+            placement='top-start'
+          >
+            <span>
+              <StyledSwitch
+                size='small'
+                checked={state.useTypescript}
+                onChange={toggleTypescript}
+                disabled
+              />
+              <Typography variant='body2' ml={1} color='gray.dark'>
+                TYPESCRIPT
+              </Typography>
+            </span>
+          </Tooltip>
         </Box>
       </Box>
     </Box>

--- a/src/renderer/internationalisation/locales/en/translation.json
+++ b/src/renderer/internationalisation/locales/en/translation.json
@@ -54,7 +54,8 @@
     "created": "Created by:"
   },
   "technology-picker": {
-    "message": "Would you like to use technology extensions?"
+    "message": "Would you like to use technology extensions?",
+    "ts-tooltip": "All projects are TypeScript compliant."
   },
   "first-time-view": {
     "title": "Choose directory",
@@ -121,7 +122,8 @@
       "username_verification_pending": "Validating..."
     },
     "PackageManager": {
-      "message": "Choose the Package Manager:"
+      "message": "Choose the Package Manager:",
+      "yarn-tooltip": "Initialization with yarn is not supported yet."
     }
   },
   "ProjectDetails": {

--- a/src/renderer/internationalisation/locales/en/translation.json
+++ b/src/renderer/internationalisation/locales/en/translation.json
@@ -55,7 +55,8 @@
   },
   "technology-picker": {
     "message": "Would you like to use technology extensions?",
-    "ts-tooltip": "All projects are TypeScript compliant."
+    "ts-tooltip": "All projects are TypeScript compliant.",
+    "sass-tooltip": "Sass is included by default in multilingual projects."
   },
   "first-time-view": {
     "title": "Choose directory",
@@ -124,6 +125,11 @@
     "PackageManager": {
       "message": "Choose the Package Manager:",
       "yarn-tooltip": "Initialization with yarn is not supported yet."
+    },
+    "LanguagesPicker": {
+      "message": "Choose language support:",
+      "single": "Single language",
+      "multi": "Multilingual"
     }
   },
   "ProjectDetails": {

--- a/src/renderer/internationalisation/locales/pl/translation.json
+++ b/src/renderer/internationalisation/locales/pl/translation.json
@@ -55,7 +55,8 @@
   },
   "technology-picker": {
     "message": "Czy chciałbyś używać następujących rozszerzeń technologii?",
-    "ts-tooltip": "Wszystkie projekty mają wsparcie dla TypeScript."
+    "ts-tooltip": "Wszystkie projekty mają wsparcie dla TypeScript.",
+    "sass-tooltip": "Projekty wielojęzyczne domyślnie posiadają wsparcie dla technologii Sass."
   },
   "first-time-view": {
     "title": "Wybierz folder",
@@ -124,6 +125,11 @@
     "PackageManager": {
       "message": "Wybierz managera pakietów:",
       "yarn-tooltip": "Generacja z użyciem yarn nie jest obecnie wspierana."
+    },
+    "LanguagesPicker": {
+      "message": "Wybierz wsparcie językowe:",
+      "single": "Jednojęzyczny",
+      "multi": "Wielojęzyczny"
     }
   },
   "ProjectDetails": {

--- a/src/renderer/internationalisation/locales/pl/translation.json
+++ b/src/renderer/internationalisation/locales/pl/translation.json
@@ -54,7 +54,8 @@
     "created": "Stworzony przez:"
   },
   "technology-picker": {
-    "message": "Czy chciałbyś używać następujących rozszerzeń technologii?"
+    "message": "Czy chciałbyś używać następujących rozszerzeń technologii?",
+    "ts-tooltip": "Wszystkie projekty mają wsparcie dla TypeScript."
   },
   "first-time-view": {
     "title": "Wybierz folder",
@@ -121,7 +122,8 @@
       "username_verification_pending": "Sprawdzanie poprawności..."
     },
     "PackageManager": {
-      "message": "Wybierz managera pakietów:"
+      "message": "Wybierz managera pakietów:",
+      "yarn-tooltip": "Generacja z użyciem yarn nie jest obecnie wspierana."
     }
   },
   "ProjectDetails": {

--- a/src/renderer/views/AddProject/subcomponents/Steps/Steps.tsx
+++ b/src/renderer/views/AddProject/subcomponents/Steps/Steps.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import LanguagesPicker from 'src/renderer/components/Languages/LanguagesPicker';
 import {
   addCollaborator,
+  AddPublicationWizard,
   deleteCollaborator,
   setPublicationField,
 } from '../../../../../shared/redux/slices/addPublicationWizardSlice';
-import { PublicationBase } from '../../../../../shared/types';
 import CollaboratorsPicker from '../../../../components/CollaboratorsPicker/CollaboratorsPicker';
 import PackageManagerPicker from '../../../../components/PackageManagerPicker/PackageManagerPicker';
 import ProjectDetailsInput from '../../../../components/ProjectDetailsInput/ProjectDetailsInput';
 import TechnologiesPicker from '../../../../components/TechnologiesPicker/TechnologiesPicker';
 
 interface Props {
-  publication: PublicationBase;
+  publication: AddPublicationWizard['data'];
 }
 
 function Details(
@@ -84,6 +85,24 @@ function Technologies(props: Props) {
   );
 }
 
+function Languages(props: Props) {
+  const dispatch = useDispatch();
+
+  return (
+    <LanguagesPicker
+      onSubmit={(state) => {
+        dispatch(
+          setPublicationField({
+            field: 'multilingual',
+            value: state.multilingual,
+          })
+        );
+      }}
+      state={props.publication}
+    />
+  );
+}
+
 function Collaborators(props: Props) {
   const dispatch = useDispatch();
 
@@ -100,4 +119,10 @@ function Collaborators(props: Props) {
   );
 }
 
-export default [Details, PackageManager, Technologies, Collaborators];
+export default [
+  Details,
+  PackageManager,
+  Languages,
+  Technologies,
+  Collaborators,
+];

--- a/src/shared/redux/slices/addPublicationWizardSlice.test.ts
+++ b/src/shared/redux/slices/addPublicationWizardSlice.test.ts
@@ -82,6 +82,7 @@ describe('addPublicationWizardSlice', () => {
         packageManager: 'npm',
         useSass: false,
         useTypescript: false,
+        multilingual: false,
       },
       step: 1,
     };
@@ -110,6 +111,7 @@ describe('addPublicationWizardSlice', () => {
         packageManager: 'npm',
         useSass: false,
         useTypescript: false,
+        multilingual: false,
       },
       step: 3,
     };
@@ -122,6 +124,7 @@ describe('addPublicationWizardSlice', () => {
         packageManager: 'npm',
         useSass: false,
         useTypescript: false,
+        multilingual: false,
       },
       step: 4,
     });
@@ -138,6 +141,7 @@ describe('addPublicationWizardSlice', () => {
         packageManager: 'npm',
         useSass: false,
         useTypescript: false,
+        multilingual: false,
       },
       step: 3,
     };

--- a/src/shared/redux/slices/addPublicationWizardSlice.ts
+++ b/src/shared/redux/slices/addPublicationWizardSlice.ts
@@ -28,7 +28,7 @@ const initialState = (): AddPublicationWizard => ({
     name: '',
     packageManager: 'npm',
     useSass: false,
-    useTypescript: false,
+    useTypescript: true,
   },
   step: 1,
 });

--- a/src/shared/redux/slices/addPublicationWizardSlice.ts
+++ b/src/shared/redux/slices/addPublicationWizardSlice.ts
@@ -5,7 +5,7 @@ import { RootState } from '../rootReducer';
 
 export type AddPublicationWizard = {
   step: number;
-  data: PublicationBase;
+  data: PublicationBase & { multilingual: boolean };
 };
 
 // type created to avoid an issue with both unclear modification type
@@ -13,11 +13,11 @@ export type AddPublicationWizard = {
 // code significantly more
 type PublicationModification = Exclude<
   {
-    [FieldName in keyof PublicationBase]: {
+    [FieldName in keyof AddPublicationWizard['data']]: {
       field: FieldName;
-      value: PublicationBase[FieldName];
+      value: AddPublicationWizard['data'][FieldName];
     };
-  }[keyof PublicationBase],
+  }[keyof AddPublicationWizard['data']],
   undefined
 >;
 const initialState = (): AddPublicationWizard => ({
@@ -29,6 +29,7 @@ const initialState = (): AddPublicationWizard => ({
     packageManager: 'npm',
     useSass: false,
     useTypescript: true,
+    multilingual: false,
   },
   step: 1,
 });
@@ -62,7 +63,7 @@ const addPublicationSlice = createSlice({
       state.data.collaborators = updatedCollaborators;
     },
     increaseStep: (state: AddPublicationWizard) => {
-      if (state.step < 5) state.step += 1;
+      if (state.step < 6) state.step += 1;
     },
     decreaseStep: (state: AddPublicationWizard) => {
       if (state.step > 1) state.step -= 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6548,6 +6548,14 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^5.7.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
+  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -9636,6 +9644,11 @@ json5@^2.1.2, json5@^2.1.3:
   dependencies:
     minimist "^1.2.5"
 
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
@@ -10347,7 +10360,7 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minimist@^1.2.5:
+minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -13522,6 +13535,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
 tar@^4:
   version "4.4.19"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
@@ -13885,6 +13903,15 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+tsconfig-paths-webpack-plugin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz#84008fc3e3e0658fdb0262758b07b4da6265ff1a"
+  integrity sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^4.0.0"
+
 tsconfig-paths@^3.12.0:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz#f3e9b8f6876698581d94470c03c95b3a48c0e3d7"
@@ -13893,6 +13920,15 @@ tsconfig-paths@^3.12.0:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"
     minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
+tsconfig-paths@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz#f8ef7d467f08ae3a695335bf1ece088c5538d2c1"
+  integrity sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==
+  dependencies:
+    json5 "^2.2.1"
+    minimist "^1.2.6"
     strip-bom "^3.0.0"
 
 tslib@^1.10.0, tslib@^1.8.1:


### PR DESCRIPTION
## Description

Certain creation options exclude each other. For now if publication is multilingual the project gets generated with sass. Typescript is used in all projects. I think in the future we will need to have a look if the template approach is the right one or should we modify the code on the users machine to get the publication template into a form that satisfies the condition. Not too important for now.

#### Inside this repository
- Fixed some storybook issues
- Improved radio and switch disabled states
- Disabled certain switches and radios in project creation
- Added tooltips to explain the disabled elements
- Added a creation step to choose whether the publication is multilingual

#### Outside of this repository
- Updated [vnLab-templates](https://github.com/vnLab-Lodz/vnLab-templates/commits/main) repository in https://github.com/vnLab-Lodz/vnLab-templates/commit/890e8154069faf89b76a9d39c0bfdf2a2eb3dd8c and https://github.com/vnLab-Lodz/vnLab-templates/commit/06e9303703447d183598a5d692d7e47bea8a617a 
- Removed sass from basic starter in https://github.com/vnLab-Lodz/gatsby-starter-paaw-basic/commit/36d1cb569b758b1a0e8599a64c4d7024d336991a
- Created sass starter → https://github.com/vnLab-Lodz/gatsby-starter-paaw-sass

## Preview

![lang](https://user-images.githubusercontent.com/34404855/191551715-ceb849d6-1360-433a-b25c-e4d9f88b6bb4.gif)

## Linked issues

Closes #243

## Correct PR Checklist

- [x] I have linked an issue (use e.g. `closes #1`)
- [x] I have assigned Reviewers
- [x] I have assigned an Description label
- [x] I have assigned a Milestone (if applicable)
