### PR TITLE
Files search

### DIFF
--- a/src/renderer/components/PublicationHeader/PublicationHeader.tsx
+++ b/src/renderer/components/PublicationHeader/PublicationHeader.tsx
@@ -8,9 +8,14 @@ import { CHANNELS } from '../../../shared/types/api';
 
 interface Props {
   sx?: SxProps<Theme>;
+  dimmedIcon?: boolean;
 }
 
-const PublicationHeader: React.FC<Props> = ({ sx = [] }) => {
+const PublicationHeader: React.FC<Props> = ({
+  children,
+  dimmedIcon,
+  sx = [],
+}) => {
   const publication = useSelector(activePublication);
   return (
     <Box
@@ -20,13 +25,14 @@ const PublicationHeader: React.FC<Props> = ({ sx = [] }) => {
       ]}
     >
       <Typography variant='h1'>{publication?.name}</Typography>
-      <Box>
+      <Box display='flex' alignItems='center'>
+        {children}
         <IconButton
           size='small'
           sx={{ borderRadius: 0, padding: 0, color: 'text.primary' }}
           onClick={() => ipcRenderer.invoke(CHANNELS.GIT.REPO_STATUS)}
         >
-          <RefreshIcon sx={{ opacity: 0.5 }} />
+          <RefreshIcon sx={{ opacity: dimmedIcon ? 0.5 : 1 }} />
         </IconButton>
       </Box>
     </Box>
@@ -35,6 +41,7 @@ const PublicationHeader: React.FC<Props> = ({ sx = [] }) => {
 
 PublicationHeader.defaultProps = {
   sx: [],
+  dimmedIcon: true,
 };
 
 export default PublicationHeader;

--- a/src/renderer/internationalisation/locales/en/translation.json
+++ b/src/renderer/internationalisation/locales/en/translation.json
@@ -189,6 +189,14 @@
       "deleted": "deleted",
       "moved": "moved",
       "unchanged": "unchanged"
+    },
+    "search": {
+      "results": "Search results for",
+      "no_directories": "folders",
+      "directories": "folders",
+      "no_files": "files",
+      "files": "files",
+      "no_match": "No {{target}} match the search phrase"
     }
   },
   "Changes": {

--- a/src/renderer/internationalisation/locales/pl/translation.json
+++ b/src/renderer/internationalisation/locales/pl/translation.json
@@ -189,6 +189,14 @@
       "deleted": "usunięty",
       "moved": "przeniesiony",
       "unchanged": "brak zmian"
+    },
+    "search": {
+      "results": "Wyniki wyszukiwania dla",
+      "no_directories": "folder",
+      "directories": "foldery",
+      "no_files": "plik",
+      "files": "pliki",
+      "no_match": "Żaden {{target}} nie pasuje do wyszukanej frazy"
     }
   },
   "Changes": {

--- a/src/renderer/views/Files/subcomponents/FileExplorer/FileExplorer.tsx
+++ b/src/renderer/views/Files/subcomponents/FileExplorer/FileExplorer.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { LocalPublication } from 'src/shared/types';
+import { findByPath } from 'src/shared/utils/repoStatus/tree';
+import { GitRepoTreeItem } from 'src/shared/types/api';
+import path from 'path';
+import { Header } from '../../../../components/FileDisplay/Columns';
+import Section from '../../../../components/Section/Section';
+import { TreeItem } from '../FileTreeItem/style';
+import ToParentFolder from '../ToParentFolder/ToParentFolder';
+import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
+import FileTreeItem from '../FileTreeItem/FileTreeItem';
+import FileTree from '../FileTree/FileTree';
+
+type Props = {
+  project: LocalPublication;
+  RepoTree: GitRepoTreeItem;
+};
+
+const FileExplorer: React.FC<Props> = ({ project, RepoTree }) => {
+  const getPath = () => path.join(project.dirPath, 'publication');
+  const [currentDirectory, setCurrentDirectory] = React.useState(getPath);
+
+  return (
+    <>
+      <Breadcrumbs
+        projectRootPath={project.dirPath}
+        dirPath={currentDirectory}
+        onClick={setCurrentDirectory}
+      />
+      <Section>
+        <Header />
+        <FileTree
+          currentDirectory={currentDirectory}
+          setCurrentDirectory={setCurrentDirectory}
+        >
+          <TreeItem
+            label={<ToParentFolder />}
+            nodeId='..'
+            treeLevel={0}
+            disabled={currentDirectory === project.dirPath}
+          />
+          <FileTreeItem
+            item={findByPath(RepoTree, currentDirectory) || RepoTree}
+            treeLevel={0}
+            dirPath={project.dirPath}
+            notRendered
+          />
+        </FileTree>
+      </Section>
+    </>
+  );
+};
+
+export default FileExplorer;

--- a/src/renderer/views/Files/subcomponents/FileSearchExplorer/FileSearchExplorer.tsx
+++ b/src/renderer/views/Files/subcomponents/FileSearchExplorer/FileSearchExplorer.tsx
@@ -1,0 +1,173 @@
+import React, { useMemo } from 'react';
+import { GitRepoTreeItem } from 'src/shared/types/api';
+import { findByPath } from 'src/shared/utils/repoStatus/tree';
+import path from 'path';
+import Section from 'src/renderer/components/Section/Section';
+import { Box, Typography } from '@mui/material';
+import { LocalPublication } from 'src/shared/types';
+import { useTranslation } from 'react-i18next';
+import FileTreeItem from '../FileTreeItem/FileTreeItem';
+import FileTree from '../FileTree/FileTree';
+
+type Props = {
+  searchTerm: string;
+  RepoTree: GitRepoTreeItem;
+  project: LocalPublication;
+};
+
+const SearchResultTree: React.FC<{
+  treePath: string;
+  tree: GitRepoTreeItem;
+  project: LocalPublication;
+}> = ({ project, treePath, tree }) => {
+  const getPath = () => path.join(project.dirPath, 'publication');
+  const [currentDirectory, setCurrentDirectory] = React.useState(getPath);
+
+  return (
+    <Box my={(theme) => theme.spacing(2)}>
+      <Box sx={{ margin: '1rem 0' }}>
+        <Typography variant='caption'>
+          . /{' '}
+          {path.relative(project.dirPath, treePath).replaceAll(path.sep, ' / ')}
+        </Typography>
+      </Box>
+      <FileTree
+        currentDirectory={currentDirectory}
+        setCurrentDirectory={setCurrentDirectory}
+      >
+        <FileTreeItem
+          item={tree}
+          treeLevel={0}
+          dirPath={project.dirPath}
+          notRendered
+        />
+      </FileTree>
+    </Box>
+  );
+};
+
+const FileSearchExplorer: React.FC<Props> = ({
+  searchTerm,
+  RepoTree,
+  project,
+}) => {
+  const { t } = useTranslation();
+
+  const [foundDirectories, foundFiles] = useMemo<
+    Readonly<[Map<string, GitRepoTreeItem>, Map<string, GitRepoTreeItem>]>
+  >(() => {
+    if (!searchTerm || !RepoTree) return [new Map(), new Map()];
+
+    const publicationPath = path.join(project.dirPath, 'publication');
+    const publication = findByPath(RepoTree, publicationPath);
+    if (!publication) return [new Map(), new Map()];
+
+    const directories = new Map<string, GitRepoTreeItem>();
+    const files = new Map<string, GitRepoTreeItem>();
+
+    const traverse = (tree: GitRepoTreeItem) => {
+      for (let i = 0; i < tree.children.length; i++) {
+        const child = tree.children[i];
+        const parts = child.filepath.split(path.sep);
+
+        if (parts.length > 0) {
+          const lastIndex = parts.length - 1;
+          const pathMatched = parts[lastIndex].includes(searchTerm);
+          const indexSearchTerm = path.join(searchTerm, 'index');
+          const indexPathTarget = path.join(...parts.slice(-2));
+
+          const indexPathMatched = indexPathTarget.includes(indexSearchTerm);
+
+          if (pathMatched || indexPathMatched) {
+            const map = child.isDirectory ? directories : files;
+            if (!map.has(child.filepath)) {
+              map.set(child.filepath, { ...tree, children: [child] });
+            }
+          }
+        }
+
+        traverse(child);
+      }
+    };
+
+    traverse(publication);
+
+    return [directories, files] as const;
+  }, [searchTerm, RepoTree]);
+
+  return (
+    <Section>
+      <Box display='flex'>
+        <Typography
+          component='h2'
+          variant='caption'
+          style={{ textTransform: 'uppercase' }}
+        >
+          {t('Files.search.results')}:{' '}
+          <Typography
+            component='span'
+            variant='body1'
+            sx={{
+              fontWeight: 'bold',
+              textTransform: 'initial',
+              ml: (theme) => theme.spacing(1),
+            }}
+          >
+            {searchTerm}
+          </Typography>
+        </Typography>
+      </Box>
+      <Box sx={{ my: (theme) => theme.spacing(3) }}>
+        <Typography
+          variant='h3'
+          component='h3'
+          mb={(theme) => theme.spacing(2)}
+        >
+          {t('Files.search.directories')}:{' '}
+          <strong>{foundDirectories.size}</strong>
+        </Typography>
+        {foundDirectories.size === 0 && (
+          <Typography variant='body1' component='p'>
+            {t('Files.search.no_match', {
+              target: t('Files.search.no_directories'),
+            })}
+          </Typography>
+        )}
+        {[...foundDirectories.entries()].map(([treePath, tree]) => (
+          <SearchResultTree
+            key={treePath}
+            tree={tree}
+            treePath={treePath}
+            project={project}
+          />
+        ))}
+      </Box>
+      <Box sx={{ my: (theme) => theme.spacing(3) }}>
+        <Typography
+          variant='h3'
+          component='h3'
+          mb={(theme) => theme.spacing(2)}
+        >
+          {t('Files.search.files')}: <strong>{foundFiles.size}</strong>
+        </Typography>
+        {foundFiles.size === 0 && (
+          <Typography variant='body1' component='p'>
+            {t('Files.search.no_match', {
+              target: t('Files.search.no_files'),
+            })}{' '}
+          </Typography>
+        )}
+        {[...foundFiles.entries()].map(([treePath, tree]) => (
+          <SearchResultTree
+            key={treePath}
+            tree={tree}
+            treePath={treePath}
+            project={project}
+          />
+        ))}
+      </Box>
+    </Section>
+  );
+};
+
+export default FileSearchExplorer;

--- a/src/renderer/views/Files/subcomponents/FileTree/FileTree.tsx
+++ b/src/renderer/views/Files/subcomponents/FileTree/FileTree.tsx
@@ -1,0 +1,63 @@
+import { ArrowDropDown, ArrowRight } from '@mui/icons-material';
+import { TreeView } from '@mui/lab';
+import path from 'path';
+import React from 'react';
+import { openInDefaultApp } from 'src/renderer/ipc';
+import {
+  isClickEvent,
+  isKeyboardEvent,
+} from 'src/shared/types/eventTypeguards';
+import { parseNodeId } from '../FileTreeItem/FileTreeItem';
+
+type Props = {
+  currentDirectory: string;
+  setCurrentDirectory: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const FileTree: React.FC<Props> = ({
+  children,
+  currentDirectory,
+  setCurrentDirectory,
+}) => {
+  const [focused, setFocused] = React.useState<string>('');
+  const [expanded, setExpanded] = React.useState<string[]>([]);
+
+  const handleToggle = (event: React.SyntheticEvent, nodeIds: string[]) => {
+    const node = parseNodeId(focused);
+    if (isOpenInteraction(event)) setCurrentDirectory(node.dirPath);
+    else setExpanded(nodeIds);
+  };
+
+  const handleSelect = (event: React.SyntheticEvent) => {
+    if (isOpenInteraction(event) && focused === '..') {
+      setCurrentDirectory(path.join(currentDirectory, focused));
+      return;
+    }
+    const node = parseNodeId(focused);
+    if (isOpenInteraction(event) && !node.isDirectory)
+      openInDefaultApp(node.dirPath);
+  };
+
+  return (
+    <TreeView
+      expanded={expanded}
+      selected='' // disable default selection behavior
+      defaultCollapseIcon={<ArrowDropDown />}
+      defaultExpandIcon={<ArrowRight />}
+      onNodeFocus={(e, value) => setFocused(value)}
+      onNodeToggle={handleToggle}
+      onNodeSelect={handleSelect}
+    >
+      {children}
+    </TreeView>
+  );
+};
+
+export default FileTree;
+
+function isOpenInteraction(event: React.SyntheticEvent) {
+  return (
+    (isKeyboardEvent(event) && event?.key === 'Enter') ||
+    (isClickEvent(event) && event.detail === 2)
+  );
+}


### PR DESCRIPTION
## Description

Files searching has been implemented. It only searches in publication for now. In the future we could play around with rendering the folders and files sections as accordions to allow collapsing in case user wants only results of one of these. Grouping the files by path could also be given a little bit of thought in a similar fashion to commits view. 

## Preview

![file-search](https://user-images.githubusercontent.com/34404855/191798394-cffb43e0-09fc-4197-a4c8-da16ab478c82.gif)

## Linked issues

Closes #224 

## Correct PR Checklist

- [x] I have linked an issue (use e.g. `closes #1`)
- [x] I have assigned Reviewers
- [x] I have assigned an Description label
- [x] I have assigned a Milestone (if applicable)
