### PR TITLE
Reinstate commit file grouping by dir path

### DIFF
--- a/src/renderer/utils/formatPath.tsx
+++ b/src/renderer/utils/formatPath.tsx
@@ -1,0 +1,7 @@
+import path from 'path';
+
+export function formatPath(filepath: string, projectDir: string) {
+  const split = path.relative(projectDir, filepath).split(path.sep);
+  split[split.length - 1] = '';
+  return `. / ${split.join(' / ')}`;
+}

--- a/src/renderer/views/Changes/subcomponents/ChangedFiles/FilesByFolder.tsx
+++ b/src/renderer/views/Changes/subcomponents/ChangedFiles/FilesByFolder.tsx
@@ -1,8 +1,12 @@
 import { Box, Typography } from '@mui/material';
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { activePublication } from 'src/shared/redux/slices/loadPublicationsSlice';
+import { LocalPublication } from 'src/shared/types';
 import { GitRepoTreeItem } from '../../../../../shared/types/api';
 import { Header } from '../../../../components/FileDisplay/Columns';
 import ChangedFile from './ChangedFile';
+import { formatPath } from '../../../../utils/formatPath';
 
 interface Props {
   items: GitRepoTreeItem[];
@@ -10,14 +14,17 @@ interface Props {
 }
 
 const FilesByFolder: React.FC<Props> = ({ items, noButtons }) => {
+  const project = useSelector(activePublication) as LocalPublication;
+
   const groupedFiles = items.reduce((_group, item) => {
     const group = _group;
-    const folderPath = formatPath(item.filepath);
+    const folderPath = formatPath(item.filepath, project.dirPath);
 
     group[folderPath] = group[folderPath] || [];
     group[folderPath].push(item);
     return group;
   }, {} as { [key: string]: GitRepoTreeItem[] });
+
   return (
     <>
       {Object.entries(groupedFiles).map(([key, files]) => (
@@ -47,9 +54,3 @@ FilesByFolder.defaultProps = {
 };
 
 export default FilesByFolder;
-
-function formatPath(filepath: string) {
-  const split = filepath.split('/');
-  split[split.length - 1] = '';
-  return `. / ${split.join(' / ')}`;
-}

--- a/src/renderer/views/Files/subcomponents/FileSearchExplorer/FileSearchExplorer.tsx
+++ b/src/renderer/views/Files/subcomponents/FileSearchExplorer/FileSearchExplorer.tsx
@@ -6,6 +6,7 @@ import Section from 'src/renderer/components/Section/Section';
 import { Box, Typography } from '@mui/material';
 import { LocalPublication } from 'src/shared/types';
 import { useTranslation } from 'react-i18next';
+import { formatPath } from 'src/renderer/utils/formatPath';
 import FileTreeItem from '../FileTreeItem/FileTreeItem';
 import FileTree from '../FileTree/FileTree';
 
@@ -27,8 +28,7 @@ const SearchResultTree: React.FC<{
     <Box my={(theme) => theme.spacing(2)}>
       <Box sx={{ margin: '1rem 0' }}>
         <Typography variant='caption'>
-          . /{' '}
-          {path.relative(project.dirPath, treePath).replaceAll(path.sep, ' / ')}
+          {formatPath(treePath, project.dirPath)}
         </Typography>
       </Box>
       <FileTree


### PR DESCRIPTION
## Description

‼️ This PR depends on #258. It will be a draft till that one is merged. 

✅ The code in this PR is final and can be review. I put #258 as target branch to allow for easy review of the relevant code.

Fixed the commits view and made the `formatPath` function reusable for us in the files search results.

## Preview

![image](https://user-images.githubusercontent.com/34404855/192035607-4bb95f87-77f2-41d4-9895-116b26913467.png)

## Linked issues
Closes #242

## Correct PR Checklist

- [x] I have linked an issue (use e.g. `closes #1`)
- [x] I have assigned Reviewers
- [x] I have assigned an Description label
- [x] I have assigned a Milestone (if applicable)
