### PR TITLE
Improve checkout when switching publications

### DIFF
--- a/src/main/lib/gitRepoHandler.ts
+++ b/src/main/lib/gitRepoHandler.ts
@@ -87,6 +87,13 @@ const createGitRepoHandler = (publication: LocalPublication) => {
 
     checkout: async (branch: string) => {
       try {
+        const currentBranch = await git.currentBranch({
+          fs,
+          dir: publication.dirPath,
+        });
+
+        if (currentBranch === branch) return;
+
         await git.checkout({
           fs,
           dir: publication.dirPath,

--- a/src/renderer/internationalisation/locales/en/translation.json
+++ b/src/renderer/internationalisation/locales/en/translation.json
@@ -36,7 +36,8 @@
     "resolving_deltas": "{{progress}} Resolving deltas",
     "analyzing_workdir": "{{progress}} Analyzing workdir",
     "updating_workdir": "{{progress}} Updating working directory",
-    "pushing": "Pushing changes from {{dir}} to the remote repository"
+    "pushing": "Pushing changes from {{dir}} to the remote repository",
+    "opening": "Opening project: \"{{title}}\". This may take a while."
   },
   "auth": {
     "in_progress": "Authentication in progress:",

--- a/src/renderer/internationalisation/locales/pl/translation.json
+++ b/src/renderer/internationalisation/locales/pl/translation.json
@@ -36,7 +36,8 @@
     "resolving_deltas": "{{progress}} Rozwiązywanie delt",
     "analyzing_workdir": "{{progress}} Analizowanie folderu roboczego",
     "updating_workdir": "{{progress}} Aktualizowanie katalogu roboczego",
-    "pushing": "Przesyłanie zmian z {{dir}} do zdalnego repozytorium"
+    "pushing": "Przesyłanie zmian z {{dir}} do zdalnego repozytorium",
+    "opening": "Otwieranie projektu: \"{{title}}\". To może chwilę potrwać."
   },
   "auth": {
     "in_progress": "Uwierzytelnianie w toku:",

--- a/src/renderer/views/ProjectsList/subcomponents/ProjectsTable/ProjectsTable.tsx
+++ b/src/renderer/views/ProjectsList/subcomponents/ProjectsTable/ProjectsTable.tsx
@@ -5,6 +5,8 @@ import { ipcRenderer } from 'electron';
 import { CHANNELS } from 'src/shared/types/api';
 import { v4 as uuidv4 } from 'uuid';
 import LoaderOverlay from 'src/renderer/components/LoaderOverlay/LoaderOverlay';
+import { addLoader, removeLoader } from 'src/shared/redux/slices/loadersSlice';
+import { useTranslation } from 'react-i18next';
 import { Publication } from '../../../../../shared/types';
 import { SUBVIEWS, VIEWS } from '../../../../constants/Views';
 import ProjectRow from './ProjectRow';
@@ -27,6 +29,7 @@ interface Props {
 const ProjectTable: React.FC<Props> = ({ publications }) => {
   const dispatch = useDispatch();
   const [loaderId, setLoaderId] = useState('');
+  const { t } = useTranslation();
 
   const selectedProject: Publication | undefined =
     useSelector(selectCurrentView).subview.props?.project;
@@ -53,9 +56,21 @@ const ProjectTable: React.FC<Props> = ({ publications }) => {
         { loaderId: uid }
       );
     }
+
     dispatch(setActivePublication(publication.id));
+
+    const uid = uuidv4();
+    setLoaderId(uid);
+    dispatch(
+      addLoader({
+        id: uid,
+        message: t('loaders.opening', { title: publication.name }),
+      })
+    );
     await ipcRenderer.invoke(CHANNELS.GIT.REPO_STATUS);
     await ipcRenderer.invoke(CHANNELS.GIT.CHECKOUT);
+    setLoaderId('');
+    dispatch(removeLoader(uid));
     dispatch(updateCurrentView(VIEWS.PROJECT));
   };
 


### PR DESCRIPTION
## Description

Couldn't immediately find any improvement for the `checkout` action in `isomorphic-git` so decided to improve the usability by not doing the `checkout` if the target branch is the current branch and added a simple loader for the publication activation in order to notify the user that things are happening in the background.

## Linked issues

Relates to #256

## Correct PR Checklist

- [x] I have linked an issue (use e.g. `closes #1`)
- [x] I have assigned Reviewers
- [x] I have assigned an Description label
- [x] I have assigned a Milestone (if applicable)
